### PR TITLE
Restructured for upgradeability and added new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # spreadcart
-This simple js based plugin helps to display an access point to the spreadshirt checkout for any webpage that uses the SpreadShop.
+This JS plugin provides a simple shopping cart for SpreadShirt's embedded javascript SpreadShop. The plugin only allows for deleting items from the cart and not for updating quantities, but it delegates deletion to a proxy server, here exemplified in PHP. The plugin can optionally display the number of items in the cart next to a shopping cart icon. It is architected to support multiple languages but so far only provides a few languages.
 
 How it works:
-* the spreadshop defines basket data in the local storage
-* plugin reads data from local storage and renders an access point to an order overview + a link to the checkout
-
+* SpreadShirt's Spreadshop script defines basket data in the local storage.
+* The plugin reads data from local storage and renders an access point to an order overview, along with a link to the checkout.
 
 How to use:
-* download
-* add to your header spreadCart.js and spreadCart.css as in the example (index.html)
-* configure the DIV that should hold the minibasket in spreadCart.js
+* Download the files (e.g. git clone).
+* Place the files `spreadCart.js`, `spreadCart_lang.js`, and `spreadCart.css` on your web site and have your pages pull them in.
+* Look at the provided `index.html` for an example of how to set up and configure your pages to use the scripts. Comments explain the parameters.
+* If you add any language strings to `spreadCart_lang.js`, please consider checking them in or otherwise supplying them to us for check in.

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 <head lang="en">
 <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="spreadCart_lang.js"></script>
 <script src="spreadCart.js"></script>
 <link rel="stylesheet" href="spreadCart.css"/>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
@@ -12,13 +13,51 @@
 <div id="myshop"></div>
 
 <script>
-    var spread_shop_config= {
-        "shopName" : "1070242",
-        "locale" : "de_DE",
-        "prefix" : "//shop.spreadshirt.de",
-        "baseId" : "myshop"
+    var spread_shop_config = {
+        shopName: "1070242",
+        locale: "de_DE",
+        prefix: "//shop.spreadshirt.de",
+        baseId: "myshop"
     };
+    
+    var pluginSpreadCart_config = {
+    
+        // language ID, as used in the spreadCart_lang.js language strings
+        lang: "de",
+        
+        // whether or not to render a shopping cart icon that shows the number
+        // of items in the cart. when false, the page instead identifies an
+        // element that is to open the shopping cart when clicked.
+        
+        showBasketIcon: true,
+        
+        // id (not a class) of the element that the user clicks on to open the
+        // shopping cart. when showBasketIcon is true, clickTargetID must
+        // identify a div. when showBasketIcon is false, clickTargetID
+        // identifies the element that is to open the shopping cart when
+        // clicked. For example, set showBasketIcon to false and clickTargetID
+        // to 'myPluginCartLink' to have the following link open the cart:
+        // "<a id='myPluginCartLink' href='#'>Shopping Cart</a>"
+        
+        clickTargetID: "myBasket",
+        
+        // .com,.de,.co.uk or any other supported domain
+        tld: "de",
+        
+        // your shop id (the ID number, not the shop name)
+        shopID: "0",
+        
+        //base URL the images will be pulled from. Needed to display product images in the basket. Change to .com (vs .net) for non-EU shops.
+        mediaURL: "//image.spreadshirtmedia.net/image-server/v1/products/",
+        
+        // location from where the customer enters checkout
+        returnURL: encodeURIComponent(window.location.href)
+    };
+
+    var strings = pluginSpreadCart_lang[pluginSpreadCart_config.lang];
+    // change strings as desired for particular site
 </script>
+
 <script type="text/javascript" src="//shop.spreadshirt.de/shopfiles/shopclient/shopclient.nocache.js"></script>
 
 </body>

--- a/spreadCart.css
+++ b/spreadCart.css
@@ -1,10 +1,3 @@
-#checkoutLink{
-    background-color: #e2122f;
-    border: 1px solid #96122c;
-    box-shadow: 0 2px 0 0 #96122c;
-    color: #f6f6f6;
-    }
-
 #miniBasketBackground{
     z-index: 100000;
     position: fixed;
@@ -43,6 +36,7 @@
 
     }
 
+#miniEmptyCart,
 #miniBasketDetails{
     padding: 20px;
     z-index: 100001;
@@ -59,6 +53,26 @@
     background-color: white;
     box-shadow: #eeeeee 2px 2px 2px ;
     }
+    
+#miniEmptyCart {
+    display: none;
+    padding: 60px;
+}
+
+#miniEmptyNotice {
+    font-size: 16px;
+    font-weight: bold;
+    text-align: center;
+}
+
+#miniEmptyOptions {
+    padding-top: 25px;
+    text-align: center;
+}
+
+#miniBasketInfo {
+    padding: 0 20px 20px 20px;
+}
 
 #miniBasketContent{
     max-height: 30em;
@@ -75,16 +89,46 @@
     color: #22262d;
     }
 
-.miniBasketButton {
-    right: 0;
+.basketItemName {
+    padding-bottom: 8px;
+}
+
+button.miniBasketButton {
     box-sizing: border-box;
     cursor: pointer;
     display: inline-block;
     padding: 0.7em 1.2em;
     text-align: center;
     vertical-align: middle;
+    font-size: 14px;
     }
 
+#miniCloseEmptyCart,
+#continueShoppingLink,
+#checkoutLink {
+    box-shadow: 2px 2px 0 0 #bbb;
+    }
+ 
+#miniCloseEmptyCart,
+#continueShoppingLink {
+    background-color: #fff;
+    border: 1px solid #000;
+    color: #000;
+    }
+
+#continueShoppingLink {
+    position: absolute;
+    left: 40px;
+    }
+
+#checkoutLink{
+    position: absolute;
+    right: 40px;
+    background-color: #e2122f;
+    border: 1px solid #96122c;
+    color: #f6f6f6;
+    }
+ 
 .basketItemInformation{
     vertical-align: top;
     padding: 20px;
@@ -95,7 +139,7 @@
     }
 
 #miniBasketOptions{
-    padding: 20px;
+    padding: 20px 0;
     border-top: dashed 2px #eeeeee
     }
 
@@ -104,6 +148,10 @@
     float: right;
     font-size: 110%;
     }
+    
+#priceTotal {
+    font-weight: bold;
+}
 
 #miniBasketFooter{
     border-top: 1px solid #eeeeee;

--- a/spreadCart.js
+++ b/spreadCart.js
@@ -1,106 +1,153 @@
-basketContainer="myBasket";//id of the div the minibasket should use. needs to be an id not a class
-tld="de"; //.com,.de,.co.uk or any other supported domain
-shopID="0";//your shop id
-mediaURL="//image.spreadshirtmedia.net/image-server/v1/products/";//base URl the images will be pulled from. Needed to display product images in the basket
-returnURL= encodeURIComponent(window.location.href);// location from where the customer enters checkout
-translations={};
-translations.currencyIndicator=" &euro;";//add the shop currency here
-translations.continueShopping="Weiter Einkaufen";// link to close the basket aka. continue Shopping
-translations.goToCheckout="Zum Checkout";//go to basket
-translations.total="Gesamtbetrag:";//total of basket
-translations.shippingTotal="Versandkosten:";//total of shipping
-translations.itemsTotal="Zwischensumme:";//total price for items
-translations.shippingInformation="inkl. Versand";//shipping information
-translations.vatInformation="inkl. MwSt. EU";//cat information
-translations.deleteItem="Aus Warenkorb entfernen";
-translations.color="Farbe: ";
-translations.size="Gr&ouml;&szlig;e: ";
-translations.quantity="Anzahl: ";
-//function to initiate basket when the document is ready
-jQuery(document).ready(function(){
-    buildCustomMiniBasket();
-    });
+/**
+Creates a shopping cart icon and a shopping cart at an indicated DIV. Must be configured via pluginSpreadCart_config and pluginSpreadCart_lang.
+**/
 
+function SpreadCartPlugin(config, stringsByLanguage) {
+    // config - values from pluginSpreadCart_config
+    // strings - values from a language of pluginSpreadCart_lang
 
-window.onSpreadShopLoaded=function(e){
-    jQuery('#addToBasket').on("click",function(){updateQuantity()});
-};
+    this.config = config;
+    this.strings = stringsByLanguage[config.lang];
 
-//button to display minibasket is appended to defined basket container, binding function to display basket to button
-function insertMiniBasketCaller(){
-    jQuery('#miniBasket').remove();
-    jQuery('#'+basketContainer).append('<div id="miniBasket" class="miniBasketButton  fa fa-shopping-cart fa-2x"><div id="totalQuantity"></div></div>');
-    jQuery('#miniBasket').on("click",function(){showMiniBasket()});
+    if(config.showBasketIcon) {
+        // only update if requested in order to allow this feature to sidestep
+        // possible issues with evolving SpreadShop implementations
+        var cart = this;
+    
+        window.onSpreadShopLoaded = function(e) {
+            jQuery('#addToBasket').on("click", function() {
+                cart.updateQuantity();
+            });
+        };
     }
-
-function getItemTotal(){
-    basketData = getBasketData();
-    itemTotal=basketData.priceItems;
-    return itemTotal;
-    }
-
-function getBasketTotal(){
-    basketData = getBasketData()
-    basketTotal=basketData.priceTotal;
-    return basketTotal;
-    }
-
-
-function getShippingTotal(){
-    basketData = getBasketData()
-    shippingTotal=basketData.priceShipping;
-    return shippingTotal;
 }
 
-function getBasketTotalQuantity(){
-    totalQuantity=0;
-    basketData = getBasketData();
-    jQuery.each( basketData.orderListItems, function(index ) {
-        totalQuantity += basketData.orderListItems[index].quantity;
-        });
-    return totalQuantity;
+//button to display minibasket is appended to defined basket container, binding function to display basket to button
+SpreadCartPlugin.prototype.insertMiniBasketCaller = function() {
+    var clickableID = '#'+this.config.clickTargetID;;
+    var cart = this;
+    
+    if(this.config.showBasketIcon) {
+        jQuery('#miniBasket').remove();
+        jQuery(clickableID).append('<div id="miniBasket" '+
+            'class="miniBasketButton  fa fa-shopping-cart fa-2x">'+
+            '<div id="totalQuantity"></div></div>');
+        clickableID = '#miniBasket';
     }
 
-function getBasketData() {
-        basketData = JSON.parse(localStorage.getItem("mmBasket"));
-        return basketData;
-        }
+    jQuery(clickableID).on("click", function() {
+        cart.showMiniBasket();
+    });
+};
 
-function buildCustomMiniBasket(){
-    basketData=getBasketData();
-    insertMiniBasketCaller();
+SpreadCartPlugin.prototype.getItemTotal = function() {
+    var basketData = this.getBasketData();
+    var itemTotal = basketData.priceItems;
+    return itemTotal;
+};
+
+SpreadCartPlugin.prototype.getBasketTotal = function() {
+    var basketData = this.getBasketData();
+    var basketTotal = basketData.priceTotal;
+    return basketTotal;
+};
+
+
+SpreadCartPlugin.prototype.getShippingTotal = function() {
+    var basketData = this.getBasketData();
+    var shippingFee = basketData.priceShipping;
+    return shippingFee;
+};
+
+SpreadCartPlugin.prototype.getBasketTotalQuantity = function() {
+    var totalQuantity = 0;
+    var basketData = this.getBasketData();
+    
+    jQuery.each(basketData.orderListItems, function(index) {
+        totalQuantity += basketData.orderListItems[index].quantity;
+    });
+    return totalQuantity;
+};
+
+SpreadCartPlugin.prototype.getBasketData = function() {
+    var basketData = JSON.parse(localStorage.getItem("mmBasket"));
+    return basketData;
+};
+
+SpreadCartPlugin.prototype.buildCustomMiniBasket = function() {
+    var basketData = this.getBasketData();
+    var cart = this;
+    
+    this.insertMiniBasketCaller();
     jQuery("body").prepend('<div id="miniBasketBackground" style="display: none"></div>');
+    jQuery('body').prepend('<div id="miniEmptyCart"><div id="miniEmptyNotice">'+
+        this.strings.emptyCart+'</div><div id="miniEmptyOptions"></div></div>');
+    jQuery('#miniEmptyOptions').append('<button class="miniBasketButton" id="miniCloseEmptyCart">'+this.strings.continueShopping+'</button>');
     jQuery('body').prepend('<div id="miniBasketDetails" style="display:none"></div>');
+
+    if(this.strings.information) {
+        jQuery('#miniBasketDetails').append('<div id="miniBasketInfo">'+
+                this.strings.information+'</div>');
+    }
     jQuery('#miniBasketDetails').append('<div id="miniBasketContent"></div>');
     jQuery('#miniBasketDetails').append('<div id="miniBasketFooter"></div>');
-    jQuery('#miniBasketFooter').append('<div class="row"> <div class="miniBasketLabel">'+translations.itemsTotal+'</div> <div class="miniBasketLabel miniBasketPrice" id="priceItems"></div> </div>');
-    jQuery('#miniBasketFooter').append('<div class="row"><div class="miniBasketLabel">'+translations.shippingTotal+'</div> <div class="miniBasketLabel miniBasketPrice" id="priceShipping"></div> </div>');
-    jQuery('#miniBasketFooter').append(' <div class="row topLine total"> <div class="miniBasketLabel">'+translations.total+'</div> <div class="miniBasketLabel miniBasketPrice" id="priceTotal"></div> </div><div class="Price><div class="" style="font-size: 60%">'+translations.vatInformation+'</div> <div class="" style="font-size: 60%">'+translations.shippingInformation+'</div><meta content="http://schema.org/InStock" itemprop="availability"></div></div>');
-    jQuery('#miniBasketFooter').append('<div id="miniBasketOptions"></div>');
-    jQuery('#miniBasketOptions').append('<button class="miniBasketButton" id="continueShoppingLink" style="position: absolute;left:20px">'+translations.continueShopping+'</button>');
-    jQuery('#miniBasketOptions').append('<button class="miniBasketButton" id="checkoutLink" style="position: absolute;right:20px">'+translations.goToCheckout+'</button>');
-    jQuery('#checkoutLink').on("click",function(){window.location="https://checkout.spreadshirt."+tld+"/?basketId="+basketData.apiBasketId+"&shopId="+shopID+"&emptyBasketUrl="+returnURL});
-    jQuery('#continueShoppingLink').on("click",function(){showMiniBasket()});
-    updateBasketContent();
+    jQuery('#miniBasketFooter').append('<div class="row"> <div class="miniBasketLabel">'+this.strings.itemsTotal+':</div> <div class="miniBasketLabel miniBasketPrice" id="priceItems"></div> </div>');
+    jQuery('#miniBasketFooter').append('<div class="row"><div class="miniBasketLabel">'+this.strings.shippingFee+':</div> <div class="miniBasketLabel miniBasketPrice" id="priceShipping"></div> </div>');
+    jQuery('#miniBasketFooter').append(' <div class="row topLine total"> <div class="miniBasketLabel">'+this.strings.total+':</div> <div class="miniBasketLabel miniBasketPrice" id="priceTotal"></div> </div><div class="Price>');
+    if(this.strings.vatInformation) {
+        jQuery('#miniBasketFooter').append('<div class="" style="font-size: 60%">'+this.strings.vatInformation+'</div> ');
     }
+    if(this.strings.shippingInformation) {
+        jQuery('#miniBasketFooter').append('<div class="" style="font-size: 60%">'+this.strings.shippingInformation+'</div>');
+    }
+    jQuery('#miniBasketFooter').append('<meta content="http://schema.org/InStock" itemprop="availability"></div></div>');
+    jQuery('#miniBasketFooter').append('<div id="miniBasketOptions"></div>');
+    jQuery('#miniBasketOptions').append('<button class="miniBasketButton" id="continueShoppingLink">'+this.strings.continueShopping+'</button>');
+    jQuery('#miniBasketOptions').append('<button class="miniBasketButton" id="checkoutLink">'+this.strings.goToCheckout+'</button>');
+    jQuery('#checkoutLink').on("click", function() {
+        window.location = "https://checkout.spreadshirt."+
+            cart.config.tld+"/?basketId="+basketData.apiBasketId+
+            "&shopId="+cart.config.shopID+
+            "&emptyBasketUrl="+cart.config.returnURL;
+    });
+
+    jQuery('#miniCloseEmptyCart').on("click", function() {
+        cart.showMiniBasket();
+    });
+    jQuery('#continueShoppingLink').on("click", function() {
+        cart.showMiniBasket();
+    });
+    jQuery('#miniBasketBackground').on("click", function() {
+        cart.showMiniBasket();
+    });
+    this.updateBasketContent();
+};
 
 //function to toggle the display of the basket and the basket background.
-    function showMiniBasket(){
+SpreadCartPlugin.prototype.showMiniBasket = function() {
+    var basketData = this.getBasketData();
+    
+    if(basketData === null || basketData.orderListItems === null ||
+            basketData.orderListItems.length == 0)
+        $( "#miniEmptyCart" ).toggle("display");
+    else {
         $( "#miniBasketDetails" ).toggle("display");
-        $( "#miniBasketBackground" ).toggle("display");
-        updateBasketContent();
-        }
+        this.updateBasketContent();
+    }
+    $( "#miniBasketBackground" ).toggle("display");
+};
 
 //deletes selected item from basket. needs proxy.php to delete it from the API basket. also updates basket in local storage that is needed to display the basket
-function deleteItem(id){
-    basketData=getBasketData();
+SpreadCartPlugin.prototype.deleteItem = function(id){
+    var basketData = getBasketData();
+    
     jQuery.ajax({
         url:'proxy.php',
         type:'POST',
         data:{
             "basketItemId":id,
             "basketId":basketData.apiBasketId,
-            "platformTLD":tld
+            "platformTLD":this.config.tld
             }
         });
     for (var i=0;i<basketData.orderListItems.length;i++) {
@@ -108,46 +155,65 @@ function deleteItem(id){
             basketData.priceTotal=basketData.priceTotal-(basketData.orderListItems[i].price*basketData.orderListItems[i].quantity);
             basketData.priceItems=basketData.priceItems-(basketData.orderListItems[i].price*basketData.orderListItems[i].quantity);
             basketData.orderListItems.splice(i,1);
-            }
         }
-    localStorage.setItem("mmBasket",JSON.stringify(basketData));
-    updateBasketContent();
     }
-
+    localStorage.setItem("mmBasket",JSON.stringify(basketData));
+    this.updateBasketContent();
+};
 
 // function to format prices properly. Basically defines that 2 decimals and a currency indicator is set
-function fixPrice(value){
-    return value.toFixed(2)+""+translations.currencyIndicator;
-    }
+SpreadCartPlugin.prototype.fixPrice = function(value) {
+    return value.toFixed(2)+""+this.strings.currencyIndicator;
+};
 
 //function to update the minibasket after removing basket items
-function updateBasketContent(){
-    basketData=getBasketData();
+SpreadCartPlugin.prototype.updateBasketContent = function() {
+    var basketData = this.getBasketData();
+    var cart = this;
+    
     jQuery('#miniBasketContent').html(" ");
     jQuery.each( basketData.orderListItems, function(index ){
         jQuery('#miniBasketContent').append('<div class="basketItem" id="basketItem-'+index+'"></div>');
-        jQuery('#basketItem-'+index).append('<img style="width:30%" src="'+mediaURL+basketData.orderListItems[index].productId+'"/>');
+        jQuery('#basketItem-'+index).append('<img style="width:30%" src="'+cart.config.mediaURL+basketData.orderListItems[index].productId+'"/>');
         jQuery('#basketItem-'+index).append('<div class="basketItemInformation" id="basketItemInformation-'+index+'"></div>');
         jQuery('#basketItemInformation-'+index).append('<div class="basketItemName">'+basketData.orderListItems[index].ptName+'</div>');
-        jQuery('#basketItemInformation-'+index).append('<div class="basketItemQuantity">'+translations.quantity+basketData.orderListItems[index].quantity+'</div>');
-        jQuery('#basketItemInformation-'+index).append('<div class="basketItemSize">'+translations.size+basketData.orderListItems[index].sizeName+'</div>');
-        jQuery('#basketItemInformation-'+index).append('<div class="basketItemColor">'+translations.color+basketData.orderListItems[index].appearanceName+'</div>');
-        jQuery('#basketItem-'+index).append('<div class="basketItemPrice " style="display:inline">'+fixPrice(basketData.orderListItems[index].price)+'</div>');
-        jQuery('#basketItemInformation-'+index).append('<div  class="miniBasketButton fa fa-trash"  style="padding-left:0px" id="delete-'+index+'">'+translations.deleteItem+'</div>');
-        jQuery('#delete-'+index).on("click",function(){deleteItem(basketData.orderListItems[index].apiId)});
+        jQuery('#basketItemInformation-'+index).append('<div class="basketItemQuantity">'+cart.strings.quantity+": "+basketData.orderListItems[index].quantity+'</div>');
+        jQuery('#basketItemInformation-'+index).append('<div class="basketItemSize">'+cart.strings.size+": "+basketData.orderListItems[index].sizeName+'</div>');
+        jQuery('#basketItemInformation-'+index).append('<div class="basketItemColor">'+cart.strings.color+": "+basketData.orderListItems[index].appearanceName+'</div>');
+        jQuery('#basketItem-'+index).append('<div class="basketItemPrice " style="display:inline">'+cart.fixPrice(basketData.orderListItems[index].price)+'</div>');
+        if(cart.strings.deleteItem) {
+            jQuery('#basketItemInformation-'+index).append('<div  class="miniBasketButton fa fa-trash"  style="padding-left:0px" id="delete-'+index+'">'+cart.strings.deleteItem+'</div>');
+            jQuery('#delete-'+index).on("click",function() {
+                cart.deleteItem(basketData.orderListItems[index].apiId)
+            });
+        }
     });
-    totalQuantity=getBasketTotalQuantity();
-    basketTotal=getBasketTotal();
-    itemTotal=getItemTotal();
-    shippingCosts=getShippingTotal();
+    
+    var totalQuantity = this.getBasketTotalQuantity();
+    var basketTotal = this.getBasketTotal();
+    var itemTotal = this.getItemTotal();
+    var shippingCosts = this.getShippingTotal();
     jQuery('#totalQuantity').html(totalQuantity);
-    jQuery('#priceTotal').html(fixPrice(basketTotal));
-    jQuery('#priceItems').html(fixPrice(itemTotal));
-    jQuery('#priceShipping').html(fixPrice(shippingCosts));
+    jQuery('#priceTotal').html(this.fixPrice(basketTotal));
+    jQuery('#priceItems').html(this.fixPrice(itemTotal));
+    jQuery('#priceShipping').html(this.fixPrice(shippingCosts));
+    return true;
+};
 
-}
-
-function updateQuantity(){
-    totalQuantity=getBasketTotalQuantity();
+SpreadCartPlugin.prototype.updateQuantity = function() {
+    var totalQuantity = this.getBasketTotalQuantity();
     jQuery('#totalQuantity').html(totalQuantity);
-}
+};
+
+//initiate basket when the document is ready
+jQuery(document).ready(function() {
+
+    // create cart on ready so cart config can be anywhere in page
+    var cart = new SpreadCartPlugin(
+        pluginSpreadCart_config,
+        pluginSpreadCart_lang
+    );
+    cart.buildCustomMiniBasket();
+});
+
+

--- a/spreadCart_lang.js
+++ b/spreadCart_lang.js
@@ -1,0 +1,62 @@
+/**
+Language strings indexed by language abbreviation. Each language entry has the following structure, where each field provides a label in the language:
+
+{
+    information, // an optional note to help the user understand the cart
+    currencyIndicator, // currency symbol to append to each monetary amount
+    quantity, // quantity of listed product
+    size, // size of a listed product
+    color, // color of a listed product
+    shippingInformation, // note about shipping (optionally empty)
+    vatInformation, // note about taxes (optionally empty)
+    deleteItem, // link for deleting item (leave empty to hide this link)
+    itemsTotal, // total cost of items excluding shipping
+    shippingFee, // fee for shipping
+    total, // sum of itemsTotal and shippingTotal
+    continueShopping, // link that closes shopping cart to continue shopping
+    goToCheckout, // link that goes to the Spreadshirt checkout
+    emptyCart, // message to display when the shopping cart is empty
+}
+
+Site developers are best off either using one of these sets of language strings or creating a new set of language strings. You may also have your site load these language strings and then subsequently modify them in your own script. It's best not to directly modify this script, so that you may overwrite this script with the latest versions of the shopping cart plugin, which may provide newly supported strings for each language.
+
+This file also allows a site to dynamically select the language according to the client.
+
+**/
+
+var pluginSpreadCart_lang = {};
+
+pluginSpreadCart_lang.de = {
+    information: "",
+    currencyIndicator: " &euro;",
+    quantity: "Anzahl",
+    size: "Gr&ouml;&szlig;e",
+    color: "Farbe",
+    shippingInformation: "inkl. Versand",
+    vatInformation: "inkl. MwSt. EU",
+    deleteItem: "Aus Warenkorb entfernen",
+    itemsTotal: "Zwischensumme",
+    shippingFee: "Versandkosten",
+    total: "Gesamtbetrag",
+    continueShopping: "Weiter Einkaufen",
+    goToCheckout: "Zum Checkout",
+    emptyCart: "Ihren Einkaufswagen ist leer"
+};
+
+pluginSpreadCart_lang.en_us = {
+    information: "",
+    currencyIndicator: " $",
+    quantity: "Quantity",
+    size: "Size",
+    color: "Color",
+    shippingInformation: "",
+    vatInformation: "(excludes any taxes that may apply)",
+    deleteItem: "Delete Item",
+    itemsTotal: "Subtotal",
+    shippingFee: "Shipping Fee",
+    total: "Total",
+    continueShopping: "Continue Shopping",
+    goToCheckout: "Checkout",
+    emptyCart: "Your shopping cart is empty"
+};
+


### PR DESCRIPTION
This revision addresses two important structural problems and implements a number of minor features. The first problem is that users were previously required to edit the file that implemented the cart in order to configure the cart to their liking. This makes it difficult for users to keep updating to the latest version of the software. The second problem is that the implementation was putting all variables and functions in the global namespace, setting the software up for random conflicts with other Javascript that the site may run. In particular, sometimes after visiting the plugin cart and then visiting the SpreadShop cart, the SpreadShop cart would report errors and empty the cart. I don't know the cause of that problem, but global variable conflicts are one possibility. This revision eliminates that possibility.

Here are the specific modifications, including a few new helpful features, and a few presentation tweaks:

(1) Configuration variable names are moved out of the global namespace into the globals pluginSpreadCart_config and pluginSpreadCart_lang. This helps to prevent name conflicts with other code that the site may be running.

(2) Configuration variable assignments (now in pluginSpreadCart_config) have been removed from spreadCart.js and must be set in the containing page. This allows users to simply replace their copy of spreadCart.js with each new version that is created, without having to manually merge changes. A sample of doing this is now in index.html.

(3) The translation variables have been moved to their own file, because they may need to be modified for the particular web site and modifications are no longer being required in spreadCart.js, and because a web site may or may not have use of all provided translations, so the developer can choose whether to use the provided translation file or to provide his/her own.

(4) The translation variables are now a function of language, allowing us to provide default translations for many languages, and allowing the site to select the translation language with a parameter.

(5) The functions implementing the plugin shopping cart have all been moved to a Javascript object, class SpreadCartPlugin. Moreover, many of the functions were using global variables for local computations instead of declaring locals. These variables are all now locals. This entailed referencing the object's variables via "this" from within object functions, and it entailed creating a local "var cart = this" for referencing the object from within anonymous functions.

(6) In the process of moving functions and variables out of global namespace, I ended up adjusting the formatting so that I could make sense of things in my 80th-column wrapping editor.

(7) Trailing colons and spaces were removed from all language strings in order to allow the formatting of the cart to evolve without having to change the language strings, some of which may be customized for a particular web site.

(8) The shipping information and tax (VAT) information lines are now optional. If values are not provided, they will not be rendered. For example, the site could select a default language and then set these values to null in that default language in order not to display this information.

(9) I renamed shippingTotal to shippingFee, because although "total shipping" can mean "shipping fee," "shipping total" can also mean total cost _including_ shipping. For clarity, I just renamed the variable.

(10) It is now optional to include the link for deleting items. The link is left out when the deleteItem language label is empty (null or blank).

(11) The cart can now be closed by clicking on the shaded background surrounding the cart. This is conventional expectation now on websites when dimming.

(12) I added the new configuration parameter showBasketIcon and renamed basketContainer to clickTargetID. When showBasketIcon is true, clickTargetID behaves as basketContainer did, naming the element where the basket icon and item quantity are to be displayed. When showBasketIcon is false, the basket icon and item quantities are not displayed. Instead, when showBasketIcon is false, clicking the clickTargetID element results in the cart being shown. The site developer puts this ID on any element he/she desires. This option has multiple benefits: (a) the plugin cart does not update its count when adjustments are made within the SpreadShop cart, so this prevents the user from ever becoming concerned over disagreeing counts; (b) the means for updating the plugin cart count rely on internal features of the SpreadShop user interface that could suddenly change on us and break the cart, so disabling updates allows us to avoid using these features, hence making the code more stable; (c) the option gives the user complete control over what the shopping cart link looks like; and (d) it can be disconcerting to see two counts on the screen at once -- the plugin cart count and the SpreadShop count (when the latter is visible).

(13) I added a new language string for information that is to be displayed at the top of the shopping cart, which defaults to empty. For example, I felt it necessary to say the following on my site: "You may change the contents of the shopping cart either at checkout or from a page that shows you T-shirts. The colors shown in these images may differ from your order; the text indicates the color ordered. Thank you for shopping!"

(14) Changed the button formatting. CSS class .miniBasketButton's padding was being ignored (a least on Chrome), so I increased the priority of the selector. I also made the font-size a readable 14px. I also moved the hardcoded style out of the HTML generation and into the stylesheet. In addition, I changed the left and right margins to 40px because I thought it looked much nicer. Also had to remove a "right:0" because this was messing up Safari. And made the drop-shadow consistent across Safari, Firefox, and Chrome.

(15) Padded below the item name a bit to make it more readable among all the item information.

(16) Modified the CSS so that the total amount is in bold.

(17) Made the shopping cart only display the language string emptyCart when the shopping cart is empty. It also displays a continue-shopping button. It's confusing to show the cart without any items and give the user totals and a checkout button, so I think we need this.
