### PR TITLE
Empty cart formatting, shrunk globals prefix, updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # spreadcart
 This JS plugin provides a simple shopping cart for SpreadShirt's embedded javascript SpreadShop. The plugin only allows for deleting items from the cart and not for updating quantities, but it delegates deletion to a proxy server, here exemplified in PHP. The plugin can optionally display the number of items in the cart next to a shopping cart icon. It is architected to support multiple languages but so far only provides a few languages.
 
+To prevent users from being confused over the presence of two shopping carts begin displayed on the web page, this plugin hides the SpreadShop cart so that only this plugin cart is available. This also prevents the item counts on the two shopping carts from getting out of sync. This measure to reduce user confusion comes at a cost to functionality. At present, the plugin cart only allows you to delete items and not to otherwise change quantities, and it only allows deletion if you employ the provided proxy server.
+
+You can deploy the plugin in any of the following ways according to you prioritize consistency vs. functionality:
+
+(1) Deploy the default configuration. The SpreadShop cart is hidden, and the plugin cart is the only means for accessing the shopping cart. The user can delete items from the cart if you also deploy the proxy server. The user cannot otherwise change the quantities of items in the cart.
+
+(2) Enable both the plugin cart and the SpreadShop cart. If the user makes changes in the SpreadShop cart, the item counts reported by the two carts will differ until the user displays the plugin cart again. This is done by setting `showBasketIcon` to true and adding the following CSS anywhere *after* `spreadCart.css` is loaded: `#basketButton{display: inline-block !important;}`.
+
+(3) Enable both carts, but disable the item count on the plugin cart, so the user will not see count discrepancies. This is done by setting `showBasketIcon` to false and adding the following CSS anywhere *after* `spreadCart.css` is loaded: `#basketButton{display: inline-block !important;}`. You will also need to add your own clickable element for displaying the cart, such as the following: `<a id="myPluginCartLink" href="#">Shopping Cart</a>`.
+
 How it works:
 * SpreadShirt's Spreadshop script defines basket data in the local storage.
 * The plugin reads data from local storage and renders an access point to an order overview, along with a link to the checkout.
 
 How to use:
-* Download the files (e.g. git clone).
+* Download the files (e.g. download the zip or do a git clone).
 * Place the files `spreadCart.js`, `spreadCart_lang.js`, and `spreadCart.css` on your web site and have your pages pull them in.
-* Look at the provided `index.html` for an example of how to set up and configure your pages to use the scripts. Comments explain the parameters.
+* Look at the provided `spreadCart_config.js` for an example of how to set up and configure your pages to use the plugin. Comments explain the parameters.
 * If you add any language strings to `spreadCart_lang.js`, please consider checking them in or otherwise supplying them to us for check in.

--- a/spreadCart.css
+++ b/spreadCart.css
@@ -37,7 +37,6 @@
 
     }
 
-#miniEmptyCart,
 #miniBasketContainer{
     padding: 20px;
     z-index: 100001;
@@ -55,19 +54,14 @@
     box-shadow: #eeeeee 2px 2px 2px ;
     }
     
-#miniEmptyCart {
-    display: none;
-    padding: 60px;
-}
-
 #miniEmptyNotice {
     font-size: 16px;
     font-weight: bold;
     text-align: center;
+    padding: 10px 0 30px 0;
 }
 
 #miniEmptyOptions {
-    padding-top: 25px;
     text-align: center;
 }
 

--- a/spreadCart.js
+++ b/spreadCart.js
@@ -1,10 +1,10 @@
 /**
-Creates a shopping cart icon and a shopping cart at an indicated DIV. Must be configured via pluginSpreadCart_config and pluginSpreadCart_lang.
+Creates a shopping cart icon and a shopping cart at an indicated DIV. Must be configured via spreadCart_config and spreadCart_lang.
 **/
 
 function SpreadCartPlugin(config, stringsByLanguage) {
-    // config - values from pluginSpreadCart_config
-    // strings - values from a language of pluginSpreadCart_lang
+    // config - values from spreadCart_config
+    // strings - values from a language of spreadCart_lang
 
     this.config = config;
     this.strings = stringsByLanguage[config.lang];
@@ -86,7 +86,7 @@ SpreadCartPlugin.prototype.buildCustomMiniBasket = function() {
     jQuery('#miniBasketContainer').append('<div id="emptyMiniBasketContainer" style="display: none"></div>');
     jQuery('#miniBasketContainer').append('<div id="filledMiniBasketContainer" style="display: none"></div>');
     jQuery('#emptyMiniBasketContainer').append('<div id="miniEmptyNotice">'+this.strings.emptyCart+'</div><div id="miniEmptyOptions"></div></div>');
-    jQuery('#emptyMiniBasketContainer').append('<button class="miniBasketButton" id="miniCloseEmptyCart">'+this.strings.continueShopping+'</button>');
+    jQuery('#miniEmptyOptions').append('<button class="miniBasketButton" id="miniCloseEmptyCart">'+this.strings.continueShopping+'</button>');
     jQuery('#filledMiniBasketContainer').append('<div id="miniBasketDetails"></div>');
 
 
@@ -221,10 +221,7 @@ SpreadCartPlugin.prototype.updateQuantity = function() {
 jQuery(document).ready(function() {
 
     // create cart on ready so cart config can be anywhere in page
-    var cart = new SpreadCartPlugin(
-        pluginSpreadCart_config,
-        pluginSpreadCart_lang
-    );
+    var cart = new SpreadCartPlugin(spreadCart_config, spreadCart_lang);
     cart.buildCustomMiniBasket();
 });
 

--- a/spreadCart_config.js
+++ b/spreadCart_config.js
@@ -1,4 +1,4 @@
-var pluginSpreadCart_config = {
+var spreadCart_config = {
 
     // language ID, as used in the spreadCart_lang.js language strings
     lang: "en_us",
@@ -32,5 +32,5 @@ var pluginSpreadCart_config = {
     returnURL: encodeURIComponent(window.location.href)
 };
 
-var strings = pluginSpreadCart_lang[pluginSpreadCart_config.lang];
+var strings = spreadCart_lang[spreadCart_config.lang];
 // change strings as desired for particular site

--- a/spreadCart_lang.js
+++ b/spreadCart_lang.js
@@ -24,9 +24,9 @@ This file also allows a site to dynamically select the language according to the
 
 **/
 
-var pluginSpreadCart_lang = {};
+var spreadCart_lang = {};
 
-pluginSpreadCart_lang.de = {
+spreadCart_lang.de = {
     information: "",
     currencyIndicator: " &euro;",
     quantity: "Anzahl",
@@ -43,7 +43,7 @@ pluginSpreadCart_lang.de = {
     emptyCart: "Ihren Einkaufswagen ist leer"
 };
 
-pluginSpreadCart_lang.en_us = {
+spreadCart_lang.en_us = {
     information: "",
     currencyIndicator: " $",
     quantity: "Quantity",


### PR DESCRIPTION
The new cart looks great! Thanks for fixing up the deletion errors I introduced. Here are the minor mods in this revision:

(1) Improved formatting of empty cart notice and removed unused #miniEmptyCart from CSS.
(2) Removed "plugin" prefix from configuration variables for readability. Now they agree with the file names. Hope you don't mind.
(3) Updated README.
