### PR TITLE
Support for node.js + ajax error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,49 @@
 # spreadcart
-This JS plugin provides a simple shopping cart for SpreadShirt's embedded javascript SpreadShop. The plugin only allows for deleting items from the cart and not for updating quantities, but it delegates deletion to a proxy server, here exemplified in PHP. The plugin can optionally display the number of items in the cart next to a shopping cart icon. It is architected to support multiple languages but so far only provides a few languages.
 
-To prevent users from being confused over the presence of two shopping carts begin displayed on the web page, this plugin hides the SpreadShop cart so that only this plugin cart is available. This also prevents the item counts on the two shopping carts from getting out of sync. This measure to reduce user confusion comes at a cost to functionality. At present, the plugin cart only allows you to delete items and not to otherwise change quantities, and it only allows deletion if you employ the provided proxy server.
+This JS plugin provides a simple shopping cart for SpreadShirt's embedded javascript SpreadShop. The plugin only allows for deleting items from the cart and not for updating quantities, but it delegates deletion to a proxy server. Proxy servers are provided for PHP and node.js. The plugin can optionally display the number of items in the cart next to a shopping cart icon. It is architected to support multiple languages but so far only provides a few languages.
 
-You can deploy the plugin in any of the following ways according to you prioritize consistency vs. functionality:
+## Read-Only Mode
+
+If you are unable to place a proxy server on your web site, you can still use the plugin in a read-only mode. Users will be able to see the contents of the shopping cart but not change quantities or delete items. However, SpreadShirt still provides the option to modify the cart on checkout. To do without the proxy server, just set the language string `deleteItem` to null.
+
+## How it works:
+
+* SpreadShirt's Spreadshop script defines basket data in the local storage.
+* The plugin reads data from local storage and renders an access point to an order overview, along with a link to the checkout.
+* Changes made to the shopping cart are directed to the proxy server on your web site, which then delegates the job to the online SpreadShirt API.
+
+## How to use:
+
+* Download the files (e.g. download the zip or do a git clone).
+* Place the files `spreadCart.js`, `spreadCart_lang.js`, and `spreadCart.css` on your web site and have your pages pull them in.
+* Look at the provided `spreadCart_config.js` for an example of how to set up and configure your pages to use the plugin. Comments explain the parameters.
+* If you add any language strings to `spreadCart_lang.js`, please consider checking them in or otherwise supplying them to us for check in.
+* If you are able to, place one of the provided proxy servers on your web site.
+
+## Presentation Options
+
+To prevent users from being confused over the presence of two shopping carts being displayed on the web page, this plugin hides the SpreadShop cart so that only this plugin cart is available. This also prevents the item counts on the two shopping carts from getting out of sync. This measure to reduce user confusion comes at a cost to functionality. At present, the plugin cart only allows you to delete items and not to otherwise change quantities, and it only allows deletion if you employ the provided proxy server.
+
+You can deploy the plugin in any of the following ways according to how you prioritize consistency vs. functionality:
 
 (1) Deploy the default configuration. The SpreadShop cart is hidden, and the plugin cart is the only means for accessing the shopping cart. The user can delete items from the cart if you also deploy the proxy server. The user cannot otherwise change the quantities of items in the cart.
 
 (2) Enable both the plugin cart and the SpreadShop cart. If the user makes changes in the SpreadShop cart, the item counts reported by the two carts will differ until the user displays the plugin cart again. This is done by setting `showBasketIcon` to true and adding the following CSS anywhere *after* `spreadCart.css` is loaded: `#basketButton{display: inline-block !important;}`.
 
-(3) Enable both carts, but disable the item count on the plugin cart, so the user will not see count discrepancies. This is done by setting `showBasketIcon` to false and adding the following CSS anywhere *after* `spreadCart.css` is loaded: `#basketButton{display: inline-block !important;}`. You will also need to add your own clickable element for displaying the cart, such as the following: `<a id="myPluginCartLink" href="#">Shopping Cart</a>`.
+(3) Enable both carts, but disable the item count on the plugin cart, so the user will not see count discrepancies. This is done by setting `showBasketIcon` to false and adding the following CSS anywhere *after* `spreadCart.css` is loaded: `#basketButton{display: inline-block !important;}`. You will also need to add your own clickable element for displaying the cart, such as the following: `<a id="myPluginCartLink">Shopping Cart</a>`. You may also want to induce link-like pointer behavior with the following CSS: `#myPluginCartLink:hover {cursor:pointer;}`.
 
-How it works:
-* SpreadShirt's Spreadshop script defines basket data in the local storage.
-* The plugin reads data from local storage and renders an access point to an order overview, along with a link to the checkout.
+## Deploying a Proxy Server
 
-How to use:
-* Download the files (e.g. download the zip or do a git clone).
-* Place the files `spreadCart.js`, `spreadCart_lang.js`, and `spreadCart.css` on your web site and have your pages pull them in.
-* Look at the provided `spreadCart_config.js` for an example of how to set up and configure your pages to use the plugin. Comments explain the parameters.
-* If you add any language strings to `spreadCart_lang.js`, please consider checking them in or otherwise supplying them to us for check in.
+We provide two proxy servers, one for PHP and one for node.js. The proxy server must go on the same web site as your store, because browsers only allow javascript to send data to the site from which the javascript was downloaded.
+
+### PHP
+
+Installing the PHP proxy should be just a matter of placing `proxy.php` in the root directory of your web site. You may place it in a different directory by changing the `proxyPath` configuration parameter. The provided configuration `spreadCart_config.js` defaults to using the PHP proxy.
+
+### node.js
+
+You have two options for installing the node.js proxy. Both use the node.js express framework. You will need to use npm to install the required modules, which are listed at the top of `server.js` and `cart.js`.
+
+If you're already running a node.js server, place the `cart.js` script in your `routes` directory and route to it from your server. The suggested route is `/cart`. Set the `proxyPath` configuration parameter to whatever route you use. You won't need the `server.js` script.
+
+If you are not already running node.js but have the ability to do so, you can use the provided basic server `server.js` to do the job. Place `server.js` and `cart.js` in the root directory and set the `proxyPath` configuration parameter to `/cart`. This server serves files from a `/public` directory that you create. Just put your SpreadShirt store HTML and supporting files in there.

--- a/nodejs/cart.js
+++ b/nodejs/cart.js
@@ -1,0 +1,87 @@
+'use strict';
+
+//// DEPENDENT MODULES ////
+
+var express = require('express');
+var crypto = require('crypto');
+var request = require('request');
+
+//// CONFIGURATION ////
+
+var API_CONTENT_TYPE = "application/xml";
+
+//// SUBROUTES ////
+
+var router = express.Router();
+router.post('/', function(req, res, next) {
+
+    if (!req.body.operation)
+        return next(new Error("missing operation"));
+
+    if (req.body.operation == "delete")
+        deleteFromCart(req.body, res, next);
+    else
+        next(new Error("unknown operation"));
+});
+
+//// SERVICES ////
+
+function deleteFromCart(params, res, next) {
+
+    var tld = params.platformTLD;
+    var basketID = params.basketId;
+    var itemID = params.basketItemId;
+    
+    if (!isValidParam(tld, 3) || !isValidParam(basketID, 100) ||
+            !isValidParam(itemID, 100)) {
+        return next(new Error("invalid parameter"));
+    }
+    
+    var url = "http://api.spreadshirt."+ tld +"/api/v1/baskets/"+
+                basketID +"/items/"+ itemID;
+    httpDelete(url, res, next);
+}
+
+//// SUPPORT FUNCTIONS ////
+
+function httpDelete(url, clientRes, next) {
+    var action = "item deletion";
+    
+    request.del(url, {
+        "Authorization": getAuthHeader("DELETE", url),
+        "Content-Type": API_CONTENT_TYPE
+    },
+    function(err, apiRes) {
+        if (err) return next(failureResponse(action, err, apiRes));
+        successResponse(action, clientRes, {});
+    });
+}
+
+function getAuthHeader(method, url) {
+    var apiKey = "";
+    var secret = "";
+    var time = new Date().getTime();
+    var apiData = method +" "+ url +" "+ time;
+    var hashData = apiData +" "+ secret;
+    var sig = crypto.createHash('sha1').update(hashData).digest('hex');
+    
+    return 'AprdAuth apiKey="'+ apiKey +'", data="'+ apiData +
+                '", sig="'+ sig +'"';
+}
+
+function isValidParam(str, maxLen) {
+    return (typeof str == "string" &&
+                /^[-a-z0-9]*$/i.test(str) && str.length <= maxLen);
+}
+
+function successResponse(action, res, data) {
+    //console.log(action +" succeeded");
+    res.send(data);
+}
+
+function failureResponse(action, err, res) {
+    return new Error(action +" failed - status: "+ err.status +
+                    ", message: "+ err.message);
+}
+
+module.exports = router;

--- a/nodejs/server.js
+++ b/nodejs/server.js
@@ -1,0 +1,53 @@
+'use strict';
+
+//// DEPENDENT MODULES ////
+
+var express = require('express');
+var bodyParser = require('body-parser');
+var path = require('path');
+
+//// HTTP PROTOCOL STACK ////
+
+var app = express();
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(express.static(path.join(__dirname, 'public')));
+
+//// REST API ROUTES ////
+
+app.use('/cart', require('./cart'));
+
+//// ERROR HANDLING ////
+
+// catch 404 and forward to error handler
+app.use(function(req, res, next) {
+    var err = new Error('Not Found');
+    err.status = 404;
+    next(err);
+});
+
+app.use(function(err, req, res, next) {
+    console.error('error: %s %s %j', req.originalUrl, err.message, err);
+    res.status(err.status || 500);
+    
+    if (req.xhr)
+        res.send({ message: err.message });
+    else {
+        var message = "Error "+ err.status +": "+ err.message;
+        res.send("<h1><center>"+ message +"</center></h1");
+    }
+});
+
+//// LAUNCH SERVER ////
+
+var port = 3000; // default to conventional port
+if (process.argv.length >= 3) {
+    if (!/^[0-9]+$/.test(process.argv[2])) {
+        console.log("invalid port number")
+        exit();
+    }
+    port = parseInt(process.argv[2]);
+}
+    
+var server = app.listen(port, function() {
+    console.log('Listening on port ' + server.address().port);
+});

--- a/spreadCart.css
+++ b/spreadCart.css
@@ -36,6 +36,10 @@
     text-align: right;
 
     }
+    
+.miniBasketButton:hover {
+    cursor: pointer;
+}
 
 #miniBasketContainer{
     padding: 20px;

--- a/spreadCart.js
+++ b/spreadCart.js
@@ -2,6 +2,8 @@
 Creates a shopping cart icon and a shopping cart at an indicated DIV. Must be configured via spreadCart_config and spreadCart_lang.
 **/
 
+//// CONSTRUCTOR ////
+
 function SpreadCartPlugin(config, stringsByLanguage) {
     // config - values from spreadCart_config
     // strings - values from a language of spreadCart_lang
@@ -23,6 +25,8 @@ function SpreadCartPlugin(config, stringsByLanguage) {
     }
 }
 
+//// PRESENTATION METHODS ////
+
 //button to display minibasket is appended to defined basket container, binding function to display basket to button
 SpreadCartPlugin.prototype.insertMiniBasketCaller = function() {
     var clickableID = '#'+this.config.clickTargetID;;
@@ -41,40 +45,6 @@ SpreadCartPlugin.prototype.insertMiniBasketCaller = function() {
     });
 };
 
-SpreadCartPlugin.prototype.getItemTotal = function() {
-    var basketData = this.getBasketData();
-    var itemTotal = basketData.priceItems;
-    return itemTotal;
-};
-
-SpreadCartPlugin.prototype.getBasketTotal = function() {
-    var basketData = this.getBasketData();
-    var basketTotal = basketData.priceTotal;
-    return basketTotal;
-};
-
-
-SpreadCartPlugin.prototype.getShippingTotal = function() {
-    var basketData = this.getBasketData();
-    var shippingFee = basketData.priceShipping;
-    return shippingFee;
-};
-
-SpreadCartPlugin.prototype.getBasketTotalQuantity = function() {
-    var totalQuantity = 0;
-    var basketData = this.getBasketData();
-    
-    jQuery.each(basketData.orderListItems, function(index) {
-        totalQuantity += basketData.orderListItems[index].quantity;
-    });
-    return totalQuantity;
-};
-
-SpreadCartPlugin.prototype.getBasketData = function() {
-    var basketData = JSON.parse(localStorage.getItem("mmBasket"));
-    return basketData;
-};
-
 SpreadCartPlugin.prototype.buildCustomMiniBasket = function() {
     var basketData = this.getBasketData();
     var cart = this;
@@ -88,7 +58,6 @@ SpreadCartPlugin.prototype.buildCustomMiniBasket = function() {
     jQuery('#emptyMiniBasketContainer').append('<div id="miniEmptyNotice">'+this.strings.emptyCart+'</div><div id="miniEmptyOptions"></div></div>');
     jQuery('#miniEmptyOptions').append('<button class="miniBasketButton" id="miniCloseEmptyCart">'+this.strings.continueShopping+'</button>');
     jQuery('#filledMiniBasketContainer').append('<div id="miniBasketDetails"></div>');
-
 
     if(this.strings.information) {
         jQuery('#miniBasketDetails').append('<div id="miniBasketInfo">'+
@@ -128,78 +97,39 @@ SpreadCartPlugin.prototype.buildCustomMiniBasket = function() {
     this.updateBasketContent();
 };
 
-//function to toggle the display of the basket and the basket background.
-SpreadCartPlugin.prototype.showMiniBasket = function() {
-    var basketData = this.getBasketData();
-    $( "#miniBasketContainer" ).toggle("display");
-    $( "#miniBasketBackground" ).toggle("display");
-    this.updateBasketContent()
-
-};
-
-//deletes selected item from basket. needs proxy.php to delete it from the API basket. also updates basket in local storage that is needed to display the basket
-SpreadCartPlugin.prototype.deleteItem = function(id){
-    var basketData = this.getBasketData();
-    
-    jQuery.ajax({
-      url:'proxy.php',
-        type:'POST',
-       data:{
-            "basketItemId":id,
-            "basketId":basketData.apiBasketId,
-            "platformTLD":this.config.tld
-            }
-        });
-    for (var i=0;i<basketData.orderListItems.length;i++) {
-        if(basketData.orderListItems[i].apiId===id) {
-            basketData.priceTotal=basketData.priceTotal-(basketData.orderListItems[i].price*basketData.orderListItems[i].quantity);
-            basketData.priceItems=basketData.priceItems-(basketData.orderListItems[i].price*basketData.orderListItems[i].quantity);
-            basketData.orderListItems.splice(i,1);
-        }
-    }
-    localStorage.setItem("mmBasket",JSON.stringify(basketData));
-    this.updateBasketContent();
-};
-
-// function to format prices properly. Basically defines that 2 decimals and a currency indicator is set
-SpreadCartPlugin.prototype.fixPrice = function(value) {
-    return value.toFixed(2)+""+this.strings.currencyIndicator;
-};
-
 //function to update the minibasket after removing basket items
 SpreadCartPlugin.prototype.updateBasketContent = function() {
     var basketData = this.getBasketData();
     var cart = this;
 
     if(basketData === null || basketData.orderListItems === null || basketData.orderListItems.length == 0 ) {
-     jQuery('#emptyMiniBasketContainer').css({"display":"inline"})
-        jQuery('#filledMiniBasketContainer').css({"display":"none"})
+        jQuery('#emptyMiniBasketContainer').css({"display":"inline"});
+        jQuery('#filledMiniBasketContainer').css({"display":"none"});
     }
-
 
     else {
         jQuery('#emptyMiniBasketContainer').css({"display":"none"})
-        jQuery('#filledMiniBasketContainer').css({"display":"inline"})
+        jQuery('#filledMiniBasketContainer').css({"display":"inline"});
 
-
-    jQuery('#miniBasketContent').html(" ");
-    jQuery.each( basketData.orderListItems, function(index ){
-        jQuery('#miniBasketContent').append('<div class="basketItem" id="basketItem-'+index+'"></div>');
-        jQuery('#basketItem-'+index).append('<img style="width:30%" src="'+cart.config.mediaURL+basketData.orderListItems[index].productId+'?appearanceId='+basketData.orderListItems[index].appearanceId+'"/>');
-        jQuery('#basketItem-'+index).append('<div class="basketItemInformation" id="basketItemInformation-'+index+'"></div>');
-        jQuery('#basketItemInformation-'+index).append('<div class="basketItemName">'+basketData.orderListItems[index].ptName+'</div>');
-        jQuery('#basketItemInformation-'+index).append('<div class="basketItemQuantity">'+cart.strings.quantity+": "+basketData.orderListItems[index].quantity+'</div>');
-        jQuery('#basketItemInformation-'+index).append('<div class="basketItemSize">'+cart.strings.size+": "+basketData.orderListItems[index].sizeName+'</div>');
-        jQuery('#basketItemInformation-'+index).append('<div class="basketItemColor">'+cart.strings.color+": "+basketData.orderListItems[index].appearanceName+'</div>');
-        jQuery('#basketItem-'+index).append('<div class="basketItemPrice " style="display:inline">'+cart.fixPrice(basketData.orderListItems[index].price)+'</div>');
-        if(cart.strings.deleteItem) {
-            jQuery('#basketItemInformation-'+index).append('<div  class="miniBasketButton fa fa-trash"  style="padding-left:0px" id="delete-'+index+'">'+cart.strings.deleteItem+'</div>');
-            jQuery('#delete-'+index).on("click",function() {
-                cart.deleteItem(basketData.orderListItems[index].apiId)
-            });
-        }
-    });
+        jQuery('#miniBasketContent').html(" ");
+        jQuery.each( basketData.orderListItems, function(index ){
+            jQuery('#miniBasketContent').append('<div class="basketItem" id="basketItem-'+index+'"></div>');
+            jQuery('#basketItem-'+index).append('<img style="width:30%" src="'+cart.config.mediaURL+basketData.orderListItems[index].productId+'?appearanceId='+basketData.orderListItems[index].appearanceId+'"/>');
+            jQuery('#basketItem-'+index).append('<div class="basketItemInformation" id="basketItemInformation-'+index+'"></div>');
+            jQuery('#basketItemInformation-'+index).append('<div class="basketItemName">'+basketData.orderListItems[index].ptName+'</div>');
+            jQuery('#basketItemInformation-'+index).append('<div class="basketItemQuantity">'+cart.strings.quantity+": "+basketData.orderListItems[index].quantity+'</div>');
+            jQuery('#basketItemInformation-'+index).append('<div class="basketItemSize">'+cart.strings.size+": "+basketData.orderListItems[index].sizeName+'</div>');
+            jQuery('#basketItemInformation-'+index).append('<div class="basketItemColor">'+cart.strings.color+": "+basketData.orderListItems[index].appearanceName+'</div>');
+            jQuery('#basketItem-'+index).append('<div class="basketItemPrice " style="display:inline">'+cart.fixPrice(basketData.orderListItems[index].price)+'</div>');
+            if(cart.strings.deleteItem) {
+                jQuery('#basketItemInformation-'+index).append('<div  class="miniBasketButton fa fa-trash"  style="padding-left:0px" id="delete-'+index+'"><a>'+cart.strings.deleteItem+'</a></div>');
+                jQuery('#delete-'+index).on("click",function() {
+                    cart.deleteItem(basketData.orderListItems[index].apiId)
+                });
+            }
+        });
     }
+    
     var totalQuantity = this.getBasketTotalQuantity();
     var basketTotal = this.getBasketTotal();
     var itemTotal = this.getItemTotal();
@@ -209,13 +139,125 @@ SpreadCartPlugin.prototype.updateBasketContent = function() {
     jQuery('#priceItems').html(this.fixPrice(itemTotal));
     jQuery('#priceShipping').html(this.fixPrice(shippingCosts));
     return true;
+};
 
+//function to toggle the display of the basket and the basket background.
+SpreadCartPlugin.prototype.showMiniBasket = function() {
+    var basketData = this.getBasketData();
+    $( "#miniBasketContainer" ).toggle("display");
+    $( "#miniBasketBackground" ).toggle("display");
+    this.updateBasketContent();
+};
+
+//// ACCESSOR METHODS ////
+
+SpreadCartPlugin.prototype.getItemTotal = function() {
+    var basketData = this.getBasketData();
+    var itemTotal = basketData.priceItems;
+    return itemTotal;
+};
+
+SpreadCartPlugin.prototype.getBasketTotal = function() {
+    var basketData = this.getBasketData();
+    var basketTotal = basketData.priceTotal;
+    return basketTotal;
+};
+
+SpreadCartPlugin.prototype.getShippingTotal = function() {
+    var basketData = this.getBasketData();
+    var shippingFee = basketData.priceShipping;
+    return shippingFee;
+};
+
+SpreadCartPlugin.prototype.getBasketTotalQuantity = function() {
+    var totalQuantity = 0;
+    var basketData = this.getBasketData();
+    
+    jQuery.each(basketData.orderListItems, function(index) {
+        totalQuantity += basketData.orderListItems[index].quantity;
+    });
+    return totalQuantity;
+};
+
+//// SERVICE METHODS ////
+
+//deletes selected item from basket. needs proxy.php to delete it from the API basket. also updates basket in local storage that is needed to display the basket
+SpreadCartPlugin.prototype.deleteItem = function(id){
+    var basketData = this.getBasketData();
+    var cart = this;
+    
+    jQuery.ajax({
+        url: this.config.proxyPath,
+        type:'POST',
+        data:{
+            "operation": "delete",
+            "basketItemId":id,
+            "basketId":basketData.apiBasketId,
+            "platformTLD":this.config.tld
+            },
+        dataType: "json",
+            
+        success: function(data, status, xhr) {
+            for (var i=0; i < basketData.orderListItems.length; i++) {
+                if(basketData.orderListItems[i].apiId===id) {
+                    basketData.priceTotal = basketData.priceTotal -
+                            (basketData.orderListItems[i].price*
+                            basketData.orderListItems[i].quantity);
+                    basketData.priceItems = basketData.priceItems -
+                            (basketData.orderListItems[i].price*
+                            basketData.orderListItems[i].quantity);
+                    basketData.orderListItems.splice(i,1);
+                    cart.putBasketData(basketData);
+                    cart.updateBasketContent();
+                }
+            }
+        },
+        
+        error: this.ajaxError
+    });
+};
+
+//// SUPPORT METHODS ////
+
+SpreadCartPlugin.prototype.getBasketData = function() {
+    var basketData = JSON.parse(localStorage.getItem("mmBasket"));
+    return basketData;
+};
+
+SpreadCartPlugin.prototype.putBasketData = function(basketData) {
+    localStorage.setItem("mmBasket", JSON.stringify(basketData));
+};
+
+// function to format prices properly. Basically defines that 2 decimals and a currency indicator is set
+SpreadCartPlugin.prototype.fixPrice = function(value) {
+    return value.toFixed(2)+""+this.strings.currencyIndicator;
 };
 
 SpreadCartPlugin.prototype.updateQuantity = function() {
     var totalQuantity = this.getBasketTotalQuantity();
     jQuery('#totalQuantity').html(totalQuantity);
 };
+
+SpreadCartPlugin.prototype.ajaxError = function(xhr, status, err) {
+    var msg = "unknown ajax error";
+
+    if (xhr.status) {
+        switch(xhr.status) {
+        case 400:
+            msg = xhr.responseText;
+            break;
+        case 404:
+            msg = "proxy service not found";
+            break;
+        case 500:
+            msg = xhr.responseJSON.message;
+            break;
+        }
+    }
+    alert("error: "+ msg);
+};
+
+//// INSTALLATION ////
 
 //initiate basket when the document is ready
 jQuery(document).ready(function() {

--- a/spreadCart_config.js
+++ b/spreadCart_config.js
@@ -29,7 +29,13 @@ var spreadCart_config = {
     mediaURL: "//image.spreadshirtmedia.net/image-server/v1/products/",
 
     // location from where the customer enters checkout
-    returnURL: encodeURIComponent(window.location.href)
+    returnURL: encodeURIComponent(window.location.href),
+    
+    // relative URL to shopping cart proxy. must be on your store's web site,
+    // as otherwise the browser will refuse for cross-origin security reasons.
+    // the last component of the path is "proxy.php" when using the provided
+    // PHP script or "/cart" when using the provided node.js server.
+    proxyPath: "proxy.php"
 };
 
 var strings = spreadCart_lang[spreadCart_config.lang];


### PR DESCRIPTION
These mods mainly support the addition of a node.js proxy, but they also improve client error handling. You might make sure I didn't break the PHP side of things.

(1) Added a node.js proxy server, including a barebones express server `server.js` and a single route `cart.js`. The route can also be plugged into existing node.js servers. The server only supports item deletion at the moment.

(2) Added proxyPath configuration parameter.

(3) Added operation proxy service parameter.

(4) Sorted methods in `spreadCart.js` by category to facilitate locating them.

(5) Now only updates cart data for deletion upon successful deletion.

(6) Proxy errors are reported via meaningful alerts. The server may return a JSON `message` parameter for error status 500, which the client displays.

(7) Made the delete-item text look like a clickable link, and turned the cursor into a pointer (as with links) when hovering over it.

(8) Tried to make the documentation more comprehensive.

I'll be working on the ability to change quantities next.
