### PR TITLE
Now builds cart in portions as becomes possible + minor fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
 </head>
 <body>
-<div id="myBasket"></div>
+<div id="spreadCartIcon"></div>
 <div id="myshop"></div>
 
 <script>

--- a/spreadCart.css
+++ b/spreadCart.css
@@ -30,7 +30,7 @@
     pointer-events: none;
     position: absolute;
     text-align: center;
-    top: -17px; /*top: -35px;*/
+    top: -17px;
     width: 2em;
     z-index: 1;
     }
@@ -61,7 +61,6 @@
     overflow-x: hidden;
     overflow-y: auto;
     background-color: white;
-    box-shadow: #eeeeee 2px 2px 2px ;
     }
     
 #miniEmptyNotice {


### PR DESCRIPTION
(1) Now builds the empty-basket notice and spreadcart icon upon page load, but only builds the "filled" portion of the cart upon getting a valid apiBasketId, which happens at least by the time an item is added to the cart.

(2) Fixed failure to update quantity upon adding to cart, which problem I introduced with the last pull request.

(3) Removed shadow from shopping cart edge. I think frills really ought to be added by the user, without having to be removed to be replaced with something else the user prefers, as I'm having to do.

(4) Defaulted demo index.html to spreadCartIcon -- forgot to do that with the last checkin.
