### PR TITLE
Revised to decouple from SpreadShop JS and use Spreadshirt APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ If you are unable to place a proxy server on your web site, you can still use th
 
 ## How it works:
 
-* SpreadShirt's Spreadshop script defines basket data in the local storage.
-* The plugin reads data from local storage and renders an access point to an order overview, along with a link to the checkout.
+* spreadCart gets the shopping basket ID from SpreadShop via shared local storage.
+* The plugin reads the shopping cart from the online Spreadshirt API and renders an access point to an order overview, along with a link to the checkout.
 * Changes made to the shopping cart are directed to the proxy server on your web site, which then delegates the job to the online SpreadShirt API.
 
 ## How to use:
@@ -28,9 +28,11 @@ You can deploy the plugin in any of the following ways according to how you prio
 
 (1) Deploy the default configuration. The SpreadShop cart is hidden, and the plugin cart is the only means for accessing the shopping cart. The user can delete items from the cart if you also deploy the proxy server. The user cannot otherwise change the quantities of items in the cart.
 
-(2) Enable both the plugin cart and the SpreadShop cart. If the user makes changes in the SpreadShop cart, the item counts reported by the two carts will differ until the user displays the plugin cart again. This is done by adding the following CSS anywhere *after* `spreadCart.css` is loaded: `#basketButton{display: inline-block !important;}`.
+(2) Enable both the plugin cart and the SpreadShop cart. If the user makes changes in the SpreadShop cart, the item counts reported by the two carts will differ until the user displays the plugin cart again, unless the decouple configuration is used. (See `spreadCart_config.js` for the advantages and disadvantages of decoupling.) You can make the SpreadShop cart visible by adding the following CSS anywhere *after* `spreadCart.css` is loaded: `#basketButton{display: inline-block !important;}`.
 
-(3) Enable both carts, but disable the item count on the plugin cart, so the user will not be concerned with apparent quantity discrepancies. This is done by setting `clickTargetID` to an ID other than `spreadCartIcon` and putting this ID on your own custom element. Here's an example custom element: `<a id="mySpreadCartLink">Shopping Cart</a>`. You may also want to induce link-like pointer behavior with the following CSS: `#mySpreadCartLink:hover {cursor:pointer;}`. In addition, to show the SpreadShop cart, add the following CSS anywhere *after* `spreadCart.css` is loaded: `#basketButton{display: inline-block !important;}`. 
+(3) [discouraged] Enable both carts, but disable the item count on the plugin cart, so the user will not be concerned with apparent quantity discrepancies. This is done by setting `clickTargetID` to an ID other than `spreadCartIcon` and putting this ID on your own custom element. Here's an example custom element: `<a id="mySpreadCartLink">Shopping Cart</a>`. You may also want to induce link-like pointer behavior with the following CSS: `#mySpreadCartLink:hover {cursor:pointer;}`. In addition, to show the SpreadShop cart, add the following CSS anywhere *after* `spreadCart.css` is loaded: `#basketButton{display: inline-block !important;}`.
+
+This plugin currently does not honor the registration of a coupon code from within the embedded SpreadShop, so it is probably best to either turn off coupon headers from the Spreadshirt shop admin or to hide the header via the CSS `#sprd-header .promo-header {display:none;}`. To activate a coupon, the user must do so from within the Spreadshirt checkout page.
 
 ## Deploying a Proxy Server
 

--- a/spreadCart.css
+++ b/spreadCart.css
@@ -22,6 +22,7 @@
 #totalQuantity{
     background: #e2122f none repeat scroll 0 0;
     border-radius: 50%;
+    font-family: Arial, Helvetica, sans-serif;
     color: white;
     font-size: 9px;
     font-weight: 700;
@@ -44,9 +45,8 @@
 
 .miniBasketPrice{
     text-align: right;
-
     }
-    
+
 #miniBasketContainer{
     padding: 20px;
     z-index: 100001;
@@ -85,7 +85,8 @@
     }
 
 .row {width: 100%;
-    position: relative;clear: both}
+    position: relative;
+    clear: both}
 .viewBasketDetails{
     background-color: #f6f6f6;
     border: 1px solid #22262d;
@@ -95,6 +96,12 @@
 
 .basketItemName {
     padding-bottom: 8px;
+}
+
+.basketItemName,
+.basketItemPrice,
+.miniBasketLabel {
+    font-size: 110%;
 }
 
 button.miniBasketButton {
@@ -113,7 +120,7 @@ button.miniBasketButton {
 
 #miniCloseEmptyCart,
 #continueShoppingLink,
-#checkoutLink {
+#miniBasketCheckoutLink {
     box-shadow: 2px 2px 0 0 #bbb;
     }
  
@@ -129,7 +136,7 @@ button.miniBasketButton {
     left: 40px;
     }
 
-#checkoutLink{
+#miniBasketCheckoutLink {
     position: absolute;
     right: 40px;
     background-color: #e2122f;
@@ -154,17 +161,24 @@ button.miniBasketButton {
 .basketItemPrice{
     padding: 20px;
     float: right;
-    font-size: 110%;
     }
     
-#priceTotal {
-    font-weight: bold;
-}
-
 #miniBasketFooter{
     border-top: 1px solid #eeeeee;
     padding: 20px;
     }
+    
+#miniBasketShippingLine .miniBasketLabel {
+    padding-bottom: 8px;
+}
+    
+.miniBasketNote {
+    font-size: 80%;
+}
+
+#priceTotal {
+    font-weight: bold;
+}
 
 @media (max-width: 768px) {
     #miniBasketConatiner{

--- a/spreadCart.js
+++ b/spreadCart.js
@@ -1,10 +1,12 @@
-/**
-Creates a shopping cart icon and a shopping cart at an indicated DIV. Must be configured via spreadCart_config and spreadCart_lang.
-**/
+/******************************************************************************
+SpreadCartPlugin is a shopping cart for SpreadShop that can be shared across multiple pages of a hosting web site. It creates a shopping cart icon at the indicated div and shows the number of items in the cart in a red bubble, although a user-provided clickable element can be used instead. It is configured via spreadCart_config and spreadCart_lang.
+******************************************************************************/
 
 //// CONSTANTS ////
 
+var ADD_TO_BASKET_ID = "addToBasket"; // ID of SpreadShop button
 var DEFAULT_ICON_ID = "spreadCartIcon"; // ID of plugin-provided cart icon
+var SPREADSHOP_WAIT_MILLIS = 500; // millis between checks for SpreadShop
 
 //// CONSTRUCTOR ////
 
@@ -12,34 +14,71 @@ function SpreadCartPlugin(config, stringsByLanguage) {
     // config - values from spreadCart_config
     // strings - values from a language of spreadCart_lang
     // showDefaultIcon - whether we're using the plugin-provided icon
+    // basketID - ID of basket in use by SpreadShop
+    // basket - SpreadCartBasket loaded via Spreadshirt API
+    // lastTotalQuantity - total quantity of items last displayed
+    // updateTriesLeft - number of attempts to update total quantity remaining
+    // updateTimer - timer that periodically tries to update total quantity
+    // basketChanged - whether user modified the basket while viewing
 
     this.config = config;
     this.strings = stringsByLanguage[config.lang];
     this.showDefaultIcon = (this.config.clickTargetID == DEFAULT_ICON_ID);
-    var cart = this;
+    this.basketID = null;
+    this.basket = null;
+    this.lastTotalQuantity = 0;
+    this.updateTriesLeft = 0;
+    this.updateTimer = null;
+    this.basketChanged = false;
+    var plugin = this;
 
-    cart.buildCustomMiniBasket();
-    
-    window.onSpreadShopLoaded = function(e) {
-        cart.buildCustomMiniBasket();
-        if(cart.showDefaultIcon) {
-            jQuery('#addToBasket').on("click", function() {
-                cart.updateQuantity();
-            });
-        }
-    };
-
+    this.buildCustomMiniBasket();
     this.insertMiniBasketCaller();
-    if(this.showDefaultIcon)
-        this.updateQuantity();
+    this.loadBasket(function(loaded) {
+        plugin.displayTotalQuantity(); // display 0 if no basket
+    });
+    
+    if(this.pageHasSpreadShop() && this.showDefaultIcon) {
+    
+        if(this.config.decouple) {
+            jQuery('*').bind("mousedown.clickmap", function(evt) {
+                plugin.clickUpdateListener();
+            });
+        }    
+        else
+            this.installSpreadShopMonitor();
+    }
 }
+
+SpreadCartPlugin.prototype.pageHasSpreadShop = function() {
+    return (typeof spread_shop_config !== 'undefined');
+};
+
+/** periodically check to see whether SpreadShop has loaded, and once it loads, install a listener on the button that adds items to the shopping cart **/
+
+SpreadCartPlugin.prototype.installSpreadShopMonitor = function() {
+
+    var $addButton = jQuery('#'+ADD_TO_BASKET_ID);
+    var plugin = this;
+
+    if($addButton.length) {
+        $addButton.on("click", function() {
+            plugin.clickUpdateListener();
+        });
+    }
+    else {
+        setTimeout(function() {
+            plugin.installSpreadShopMonitor();
+        }, SPREADSHOP_WAIT_MILLIS);
+    }
+};
 
 //// PRESENTATION METHODS ////
 
 //button to display minibasket is appended to defined basket container, binding function to display basket to button
 SpreadCartPlugin.prototype.insertMiniBasketCaller = function() {
     var clickableID = '#'+this.config.clickTargetID;;
-    var cart = this;
+    var plugin = this;
     
     if(this.showDefaultIcon) {
         jQuery('#miniBasket').remove();
@@ -50,204 +89,313 @@ SpreadCartPlugin.prototype.insertMiniBasketCaller = function() {
     }
 
     jQuery(clickableID).on("click", function() {
-        cart.showMiniBasket();
+        plugin.loadBasket(function(loaded) {
+            plugin.openMiniBasket();
+        });
     });
 };
 
 SpreadCartPlugin.prototype.buildCustomMiniBasket = function() {
-    var basketData = this.getBasketData();
-    var cart = this;
+    var plugin = this;
+
+    // build the dimmed basket background
     
-    if(!$('#emptyMiniBasketContainer').length) {
+    jQuery('body').prepend('<div id="miniBasketBackground" style="display: none"></div>');
+    jQuery('#miniBasketBackground').on("click", function() {
+        plugin.closeMiniBasket();
+    });
 
-        jQuery('body').prepend('<div id="miniBasketBackground" style="display: none"></div>');
-        jQuery('body').prepend('<div id="miniBasketContainer" style="display: none"></div>');
-        jQuery('#miniBasketContainer').append('<div id="emptyMiniBasketContainer" style="display: none"></div>');
-        jQuery('#emptyMiniBasketContainer').append('<div id="miniEmptyNotice">'+this.strings.emptyCart+'</div><div id="miniEmptyOptions"></div></div>');
-        jQuery('#miniEmptyOptions').append('<button class="miniBasketButton" id="miniCloseEmptyCart">'+this.strings.continueShopping+'</button>');
-
-        jQuery('#miniCloseEmptyCart').on("click", function() {
-            cart.showMiniBasket();
-        });
-        jQuery('#miniBasketBackground').on("click", function() {
-            cart.showMiniBasket();
-        });
-    }
-
-    if(!$('#filledMiniBasketContainer').length && basketData !== null &&
-            typeof basketData.apiBasketId !== "undefined") {
+    // build the empty basket
     
-        jQuery('#miniBasketContainer').append('<div id="filledMiniBasketContainer" style="display: none"></div>');
-        jQuery('#filledMiniBasketContainer').append('<div id="miniBasketDetails"></div>');
+    jQuery('body').prepend('<div id="miniBasketContainer" style="display: none"></div>');
+    jQuery('#miniBasketContainer').append('<div id="emptyMiniBasketContainer" style="display: none"></div>');
+    jQuery('#emptyMiniBasketContainer').append('<div id="miniEmptyNotice">'+this.strings.emptyCart+'</div><div id="miniEmptyOptions"></div></div>');
+    jQuery('#miniEmptyOptions').append('<button class="miniBasketButton" id="miniCloseEmptyCart">'+this.strings.continueShopping+'</button>');
 
-        if(this.strings.information) {
-            jQuery('#miniBasketDetails').append('<div id="miniBasketInfo">'+
-                    this.strings.information+'</div>');
-        }
-        jQuery('#miniBasketDetails').append('<div id="miniBasketContent"></div>');
-        jQuery('#miniBasketDetails').append('<div id="miniBasketFooter"></div>');
-        jQuery('#miniBasketFooter').append('<div class="row"> <div class="miniBasketLabel">'+this.strings.itemsTotal+':</div> <div class="miniBasketLabel miniBasketPrice" id="priceItems"></div> </div>');
-        jQuery('#miniBasketFooter').append('<div class="row"><div class="miniBasketLabel">'+this.strings.shippingFee+':</div> <div class="miniBasketLabel miniBasketPrice" id="priceShipping"></div> </div>');
-        jQuery('#miniBasketFooter').append(' <div class="row topLine total"> <div class="miniBasketLabel">'+this.strings.total+':</div> <div class="miniBasketLabel miniBasketPrice" id="priceTotal"></div> </div><div class="Price>');
-        if(this.strings.vatInformation) {
-            jQuery('#miniBasketFooter').append('<div class="" style="font-size: 60%">'+this.strings.vatInformation+'</div> ');
-        }
-        if(this.strings.shippingInformation) {
-            jQuery('#miniBasketFooter').append('<div class="" style="font-size: 60%">'+this.strings.shippingInformation+'</div>');
-        }
-        jQuery('#miniBasketFooter').append('<meta content="http://schema.org/InStock" itemprop="availability"></div></div>');
-        jQuery('#miniBasketFooter').append('<div id="miniBasketOptions"></div>');
-        jQuery('#miniBasketOptions').append('<button class="miniBasketButton" id="continueShoppingLink">'+this.strings.continueShopping+'</button>');
-        jQuery('#miniBasketOptions').append('<button class="miniBasketButton" id="checkoutLink">'+this.strings.goToCheckout+'</button>');
-        jQuery('#checkoutLink').on("click", function() {
-            window.location = cart.getCheckoutURL();
-        });
+    jQuery('#miniCloseEmptyCart').on("click", function() {
+        plugin.closeMiniBasket();
+    });
+    
+    // build the filled basket
 
-        jQuery('#continueShoppingLink').on("click", function() {
-            cart.showMiniBasket();
-        });
-        this.updateBasketContent();
+    jQuery('#miniBasketContainer').append('<div id="filledMiniBasketContainer" style="display: none"></div>');
+    jQuery('#filledMiniBasketContainer').append('<div id="miniBasketDetails"></div>');
+
+    if(this.strings.information) {
+        jQuery('#miniBasketDetails').append('<div id="miniBasketInfo">'+
+                this.strings.information+'</div>');
     }
+    jQuery('#miniBasketDetails').append('<div id="miniBasketContent"></div>');
+    
+    jQuery('#miniBasketDetails').append('<div id="miniBasketFooter"></div>');
+    jQuery('#miniBasketFooter').append('<div class="row"> <div class="miniBasketLabel">'+this.strings.itemsTotal+':</div> <div class="miniBasketLabel miniBasketPrice" id="priceItems"></div> </div>');
+    jQuery('#miniBasketFooter').append('<div class="row" id="miniBasketShippingLine"><div class="miniBasketLabel">'+this.strings.shippingFee+':</div> <div class="miniBasketLabel miniBasketPrice" id="priceShipping"></div> </div>');
+    jQuery('#miniBasketFooter').append(' <div id="miniBasketTotalLine" class="row"> <div class="miniBasketLabel">'+this.strings.total+':</div> <div class="miniBasketLabel miniBasketPrice" id="priceTotal"></div> <div </div>');
+    
+    if(this.strings.vatInformation) {
+        jQuery('#miniBasketFooter').append('<div class="miniBasketNote">'+this.strings.vatInformation+'</div> ');
+    }
+    if(this.strings.shippingInformation) {
+        jQuery('#miniBasketFooter').append('<div class="miniBasketNote">'+this.strings.shippingInformation+'</div>');
+    }
+    jQuery('#miniBasketFooter').append('<meta content="http://schema.org/InStock" itemprop="availability"></div></div>');
+    
+    jQuery('#miniBasketFooter').append('<div id="miniBasketOptions"></div>');
+    jQuery('#miniBasketOptions').append('<button class="miniBasketButton" id="continueShoppingLink">'+this.strings.continueShopping+'</button>');
+    jQuery('#miniBasketOptions').append('<button class="miniBasketButton" id="miniBasketCheckoutLink">'+this.strings.goToCheckout+'</button>');
+
+    jQuery('#continueShoppingLink').on("click", function() {
+        plugin.closeMiniBasket();
+    });
+    jQuery('#miniBasketCheckoutLink').on("click", function() {
+        window.location = plugin.getCheckoutURL();
+    });
 };
 
-//function to update the minibasket after removing basket items
-SpreadCartPlugin.prototype.updateBasketContent = function() {
-    var basketData = this.getBasketData();
-    var cart = this;
+SpreadCartPlugin.prototype.buildCartItems = function() {
+    var plugin = this;
 
-    if(basketData === null || basketData.orderListItems === null || basketData.orderListItems.length == 0 ) {
+    if(this.basket === null)
+        return;
+    jQuery('#miniBasketContent').html(" ");
+    jQuery.each(this.basket.basketItems, function(itemIndex){
+        var basketItem = plugin.basket.basketItems[itemIndex];
+        
+        var itemDivID = 'basketItem-'+ basketItem.id;
+        jQuery('#miniBasketContent').append('<div class="basketItem" id="'+ itemDivID +'"></div>');
+        var itemDiv = jQuery('#'+ itemDivID);
+        itemDiv.append('<img style="width:30%" src="'+ plugin.config.mediaURL + basketItem.element.id +'?appearanceId='+  basketItem.element.properties['appearance'] +'"/>');
+        
+        var infoDivID = 'basketItemInformation-'+ basketItem.id;
+        itemDiv.append('<div class="basketItemInformation" id="'+ infoDivID +'"></div>');
+        var infoDiv = jQuery('#'+ infoDivID);
+        infoDiv.append('<div class="basketItemName">'+ basketItem.description +'</div>');
+        infoDiv.append('<div class="basketItemQuantity">'+ plugin.strings.quantity +": "+ basketItem.quantity +'</div>');
+        infoDiv.append('<div class="basketItemSize">'+ plugin.strings.size +": "+ basketItem.element.properties['sizeLabel'] +'</div>');
+        infoDiv.append('<div class="basketItemColor">'+ plugin.strings.color +": "+ basketItem.element.properties['appearanceLabel'] +'</div>');
+        itemDiv.append('<div class="basketItemPrice " style="display:inline">'+ plugin.formatPrice(plugin.basket.getUndiscountedItemCost(itemIndex)) +'</div>');
+        
+        if(plugin.strings.deleteItem) {
+            infoDiv.append('<div  class="miniBasketButton fa fa-trash"  style="padding-left:0px" id="delete-'+ basketItem.id +'"><a>'+ plugin.strings.deleteItem +'</a></div>');
+            jQuery('#delete-'+ basketItem.id).on("click", function() {
+                plugin.requestDeleteItem(basketItem.id, itemDivID)
+            });
+        }
+    });
+};
+
+SpreadCartPlugin.prototype.displayTotalQuantity = function() {
+    var totalQuantity = this.getBasketTotalQuantity();
+    
+    if(this.config.stateHandler !== null) {
+        if(totalQuantity == 0) {
+            if(this.lastTotalQuantity > 0)
+                this.config.stateHandler(null);
+        }
+        else if(this.lastTotalQuantity === 0)
+            this.config.stateHandler(this.getCheckoutURL());
+    }
+    this.lastTotalQuantity = totalQuantity;
+    
+    if(this.showDefaultIcon)
+        jQuery('#totalQuantity').html(totalQuantity);
+};
+
+SpreadCartPlugin.prototype.updateCartTotals = function() {
+
+    // may need to switch to or from an empty cart 
+    if(this.basket === null || this.basket.basketItems.length == 0 ) {
         jQuery('#emptyMiniBasketContainer').css({"display":"inline"});
         jQuery('#filledMiniBasketContainer').css({"display":"none"});
     }
-
     else {
         jQuery('#emptyMiniBasketContainer').css({"display":"none"})
         jQuery('#filledMiniBasketContainer').css({"display":"inline"});
-
-        jQuery('#miniBasketContent').html(" ");
-        jQuery.each( basketData.orderListItems, function(index ){
-            jQuery('#miniBasketContent').append('<div class="basketItem" id="basketItem-'+index+'"></div>');
-            jQuery('#basketItem-'+index).append('<img style="width:30%" src="'+cart.config.mediaURL+basketData.orderListItems[index].productId+'?appearanceId='+basketData.orderListItems[index].appearanceId+'"/>');
-            jQuery('#basketItem-'+index).append('<div class="basketItemInformation" id="basketItemInformation-'+index+'"></div>');
-            jQuery('#basketItemInformation-'+index).append('<div class="basketItemName">'+basketData.orderListItems[index].ptName+'</div>');
-            jQuery('#basketItemInformation-'+index).append('<div class="basketItemQuantity">'+cart.strings.quantity+": "+basketData.orderListItems[index].quantity+'</div>');
-            jQuery('#basketItemInformation-'+index).append('<div class="basketItemSize">'+cart.strings.size+": "+basketData.orderListItems[index].sizeName+'</div>');
-            jQuery('#basketItemInformation-'+index).append('<div class="basketItemColor">'+cart.strings.color+": "+basketData.orderListItems[index].appearanceName+'</div>');
-            jQuery('#basketItem-'+index).append('<div class="basketItemPrice " style="display:inline">'+cart.fixPrice(basketData.orderListItems[index].price)+'</div>');
-            if(cart.strings.deleteItem) {
-                jQuery('#basketItemInformation-'+index).append('<div  class="miniBasketButton fa fa-trash"  style="padding-left:0px" id="delete-'+index+'"><a>'+cart.strings.deleteItem+'</a></div>');
-                jQuery('#delete-'+index).on("click",function() {
-                    cart.deleteItem(basketData.orderListItems[index].apiId)
-                });
-            }
-        });
-    
-        var basketTotal = basketData.priceTotal;
-        var itemTotal = basketData.priceItems;
-        var shippingCosts = basketData.priceShipping;
-        jQuery('#priceTotal').html(this.fixPrice(basketTotal));
-        jQuery('#priceItems').html(this.fixPrice(itemTotal));
-        jQuery('#priceShipping').html(this.fixPrice(shippingCosts));
-    }
-
-    this.updateQuantity();
-    return true;
-};
-
-//function to toggle the display of the basket and the basket background.
-SpreadCartPlugin.prototype.showMiniBasket = function() {
-    var basketData = this.getBasketData();
-    $( "#miniBasketContainer" ).toggle("display");
-    $( "#miniBasketBackground" ).toggle("display");
-    this.updateBasketContent();
-};
-
-//// SERVICE METHODS ////
-
-//deletes selected item from basket. needs proxy.php to delete it from the API basket. also updates basket in local storage that is needed to display the basket
-SpreadCartPlugin.prototype.deleteItem = function(id){
-    var basketData = this.getBasketData();
-    var cart = this;
-    
-    jQuery.ajax({
-        url: this.config.proxyPath,
-        type:'POST',
-        data:{
-            "operation": "delete",
-            "basketItemId":id,
-            "basketId":basketData.apiBasketId,
-            "platformTLD":this.config.tld
-            },
-        dataType: "json",
-            
-        success: function(data, status, xhr) {
-            for (var i=0; i < basketData.orderListItems.length; i++) {
-                if(basketData.orderListItems[i].apiId===id) {
-                    basketData.priceTotal = basketData.priceTotal -
-                            (basketData.orderListItems[i].price*
-                            basketData.orderListItems[i].quantity);
-                    basketData.priceItems = basketData.priceItems -
-                            (basketData.orderListItems[i].price*
-                            basketData.orderListItems[i].quantity);
-                    basketData.orderListItems.splice(i,1);
-                    cart.putBasketData(basketData);
-                    cart.updateBasketContent();
-                }
-            }
-        },
         
-        error: this.ajaxError
-    });
+        var itemTotal = this.basket.getUndiscountedItemSubtotal();
+        var shippingCosts = this.basket.getShippingCost();
+        var priceTotal = this.basket.getUndiscountedTotal();
+        
+        jQuery('#priceItems').html(this.formatPrice(itemTotal));
+        jQuery('#priceShipping').html(this.formatPrice(shippingCosts));
+        jQuery('#priceTotal').html(this.formatPrice(priceTotal));
+    }
+};
+
+SpreadCartPlugin.prototype.openMiniBasket = function() {
+    this.basketChanged = false;
+    this.displayTotalQuantity(); // basket may have just loaded
+    this.buildCartItems();
+    this.updateCartTotals();
+    $("#miniBasketContainer").toggle(true);
+    $("#miniBasketBackground").toggle(true);
+};
+
+SpreadCartPlugin.prototype.closeMiniBasket = function() {
+
+    // have to reload pages that have SpreadShop to force SpreadShop to reload
+    // the basket from the Spreadshirt API and get any changes made here
+    if(this.pageHasSpreadShop() && this.basketChanged)
+        location.reload();
+    else {
+        $("#miniBasketContainer").toggle(false);
+        $("#miniBasketBackground").toggle(false);
+    }
 };
 
 //// BASKET METHODS ////
 
-SpreadCartPlugin.prototype.getBasketData = function() {
-    var basketData = JSON.parse(localStorage.getItem("mmBasket"));
-    return basketData;
+SpreadCartPlugin.prototype.clickUpdateListener = function() {
+    var plugin = this;
+
+    if(this.updateTimer !== null)
+        clearTimeout(this.updateTimer);
+
+    this.updateTriesLeft = this.config.updateTries;
+    this.updateTimer = setTimeout(function() {
+            plugin.tryUpdatingQuantity();
+        }, this.config.updateMillis);
 };
 
-SpreadCartPlugin.prototype.putBasketData = function(basketData) {
-    localStorage.setItem("mmBasket", JSON.stringify(basketData));
+SpreadCartPlugin.prototype.tryUpdatingQuantity = function() {
+    var plugin = this;
+
+    this.loadBasket(function(loaded) {
+        if(loaded) {
+            if(plugin.lastTotalQuantity !== plugin.getBasketTotalQuantity())
+                plugin.displayTotalQuantity();
+            else {
+                if(--plugin.updateTriesLeft > 0) {
+                    plugin.updateTimer = setTimeout(function() {
+                            plugin.tryUpdatingQuantity();
+                        }, plugin.config.updateMillis);
+                }
+            }
+        }
+        else { // don't keep trying if basket is invalid
+            plugin.updateTriesLeft = 0;
+            plugin.displayTotalQuantity(); // display 0
+        }
+    });
+};
+
+SpreadCartPlugin.prototype.loadBasket = function(nextFunc) {
+
+    // allow possibility that basket ID may dynamically change
+    var shopBasketJSON = localStorage.getItem("mmBasket");
+    var plugin = this;
+    this.basketID = null;
+    
+    if(shopBasketJSON !== null && shopBasketJSON !== "") {
+        var shopBasket = JSON.parse(shopBasketJSON);
+        
+        if(shopBasket !== null) {
+            this.basketID = shopBasket.apiBasketId;
+            this.requestReadBasket(nextFunc);
+        }
+    }
+    
+    // empty the basket if we ever lose the SpreadShop basket ID
+    if(this.basketID === null) {
+        this.basket = null;
+        nextFunc();
+    }
 };
 
 SpreadCartPlugin.prototype.getBasketTotalQuantity = function() {
-    var totalQuantity = 0;
-    var basketData = this.getBasketData();
-    
-    if (basketData !== null && basketData.orderListItems !== null) {
-        jQuery.each(basketData.orderListItems, function(index) {
-            totalQuantity += basketData.orderListItems[index].quantity;
-        });
-    }
-    return totalQuantity;
-};
-
-SpreadCartPlugin.prototype.updateQuantity = function() {
-    var totalQuantity = this.getBasketTotalQuantity();
-    if(this.config.stateHandler !== null) {
-        if(totalQuantity == 0)
-            this.config.stateHandler(null);
-        else
-            this.config.stateHandler(this.getCheckoutURL());
-    }
-    jQuery('#totalQuantity').html(totalQuantity);
+    if(this.basket === null)
+        return 0;
+    return this.basket.getTotalQuantity();
 };
 
 SpreadCartPlugin.prototype.getCheckoutURL = function() {
-    var basketData = this.getBasketData();
-
     return "https://checkout.spreadshirt."+
-            this.config.tld +"/?basketId="+ basketData.apiBasketId+
+            this.config.tld +"/?basketId="+ this.basketID +
             "&shopId="+ this.config.shopID +
-            "&emptyBasketUrl="+ this.config.returnURL;
+            "&emptyBasketUrl="+ encodeURIComponent(this.config.returnURL);
 }
+
+//// SERVICE METHODS ////
+
+SpreadCartPlugin.prototype.requestReadBasket = function(nextFunc) {
+    var plugin = this;
+    
+    this.proxyRequest("read", this.basketID, {},
+        function(data, status, xhr) {
+
+            var basketDoc = jQuery.parseXML(xhr.responseJSON.xml);
+
+            // update for successfully read (non-empty) basket
+            if(jQuery(basketDoc).find('basketItem').length) {
+                try {
+                    plugin.basket = new SpreadCartBasket(basketDoc);
+                }        
+                catch(e) {
+                    if(e instanceof ElementNotFoundException ||
+                            e instanceof UnexpectedValueException)
+                    {
+                        alert(e.message);
+                        // don't null the basket, in case it's temporary
+                    }
+                    else
+                        throw e;
+                }
+                nextFunc(true);
+            }
+            
+            // detect basket that becomes invalid after purchase
+            else {
+                plugin.basketID = null;
+                plugin.basket = null;
+                nextFunc(false);
+            }
+        });
+};
+
+SpreadCartPlugin.prototype.requestDeleteItem = function(itemID, itemDivID){
+    var requestData = { "basketItemId": itemID };
+    var plugin = this;
+
+    this.proxyRequest("delete", this.basketID, requestData,
+        function(data, status, xhr) {
+
+            // provide the user with immediate feedback
+            var itemDiv = jQuery('#'+ itemDivID);
+            if(itemDiv.length) // if not already lost via loadBasket()
+                itemDiv.remove();
+            plugin.basketChanged = true;
+                
+            // reread the basket to get new shipping cost, etc.
+            plugin.requestReadBasket(function(loaded) {
+                plugin.displayTotalQuantity();
+                plugin.updateCartTotals();
+            });
+        });
+};
 
 //// SUPPORT METHODS ////
 
-// function to format prices properly. Basically defines that 2 decimals and a currency indicator is set
-SpreadCartPlugin.prototype.fixPrice = function(value) {
-    return value.toFixed(2)+""+this.strings.currencyIndicator;
+SpreadCartPlugin.prototype.proxyRequest = function(action, basketID,
+        requestData, successFunc) {
+
+    var allRequestData = {
+        "action": action,
+        "platformTLD": this.config.tld,
+        "basketId": basketID
+    };
+
+    var params = Object.keys(requestData);
+    for(var i=0; i < params.length; ++i)
+        allRequestData[params[i]] = requestData[params[i]];
+    
+    jQuery.ajax({
+        url: this.config.proxyPath,
+        type:'POST',
+        data: allRequestData,
+        dataType: "json",
+        success: successFunc,
+        error: this.ajaxError
+    });
 };
 
 SpreadCartPlugin.prototype.ajaxError = function(xhr, status, err) {
@@ -269,6 +417,11 @@ SpreadCartPlugin.prototype.ajaxError = function(xhr, status, err) {
     alert("error: "+ msg);
 };
 
+// function to format prices properly. Basically defines that 2 decimals and a currency indicator is set
+SpreadCartPlugin.prototype.formatPrice = function(value) {
+    return value.toFixed(2)+""+this.strings.currencyIndicator;
+};
+
 //// INSTALLATION ////
 
 //initiate basket when the document is ready
@@ -278,4 +431,197 @@ jQuery(document).ready(function() {
     new SpreadCartPlugin(spreadCart_config, spreadCart_lang);
 });
 
+/******************************************************************************
+SpreadCartBasket is a representation of the data in a SpreadShop shopping cart. It is initialized with the XML returned via the API for reading the cart.
+******************************************************************************/
 
+/** constructor. caller provides a jQuery object basketDoc representing the parsed XML document from the Spreadshirt API. caller must catch exceptions **/
+
+function SpreadCartBasket(basketDoc) {
+    // id (string)
+    // basketItems[] (array)
+    // . id (string)
+    // . description (string)
+    // . quantity (int)
+    // . element
+    // . . id (string)
+    // . . properties[] (associative array)
+    // . priceItem (priceInfo) - price per item without discounts
+    // . price (priceInfo) - price per item with discounts
+    // shipping
+    // . priceItem (priceInfo)
+    // . price (priceInfo)
+    // priceItems (priceInfo) - total without shipping, without discounts
+    // priceTotal (priceInfo) - total with shipping and discounts
+    
+    // each priceInfo is structured as follows:
+    // . vatExcluded (float)
+    // . vatIncluded (float)
+    // . display (float)
+    // . vat (float) - apparently only present in shipping element
+
+    var $basket = jQuery(basketDoc).children('basket');
+    var basket = this;
+    
+    // load basket-specific information
+    
+    this.id = basket.stringAttr($basket, 'basket', 'id');
+    
+    // load each basket item, if any
+    
+    this.basketItems = [];
+    $basket.find('basketItem').each(function() {
+        var $item = jQuery(this);
+        var item = {};
+        item.id = basket.stringAttr($item, "basketItem", 'id');
+        item.description = basket.stringElem($item, 'description');
+        item.quantity = basket.intElem($item, 'quantity');
+        
+        var $element = basket.getChildren($item, 'element');
+        var element = item.element = {};
+        element.id = basket.stringAttr($element, 'element', 'id');
+        element.properties = {};
+        $element.find('property').each(function() {
+            var $property = jQuery(this);
+            element.properties[$property.attr('key')] = $property.text();
+        });
+        
+        item.priceItem = basket.getPriceInfo($item, 'priceItem');
+        item.price = basket.getPriceInfo($item, 'price');
+        
+        basket.basketItems.push(item);
+    });
+    
+    // load the shipping information
+    
+    var $shipping = basket.getChildren($basket, 'shipping');
+    var shipping = basket.shipping = {};
+    shipping.priceItem = basket.getPriceInfo($shipping, 'priceItem');
+    shipping.price = basket.getPriceInfo($shipping, 'price');
+    
+    // load the shopping cart totals
+    
+    basket.priceItems = basket.getPriceInfo($basket, 'priceItems');
+    basket.priceTotal = basket.getPriceInfo($basket, 'priceTotal');
+}
+
+//// ACCESSORS ////
+
+SpreadCartBasket.prototype.getTotalQuantity = function() {
+    var quantity = 0;
+
+    for(var i=0; i < this.basketItems.length; ++i)
+        quantity += this.basketItems[i].quantity;
+    return quantity;
+};
+
+SpreadCartBasket.prototype.getDiscountedItemCost = function(itemIndex) {
+    var item = this.basketItems[itemIndex];
+    return item.quantity * item.price.vatExcluded;
+};
+
+SpreadCartBasket.prototype.getUndiscountedItemCost = function(itemIndex) {
+    var item = this.basketItems[itemIndex];
+    return item.quantity * item.priceItem.vatExcluded;
+};
+
+SpreadCartBasket.prototype.getDiscountedItemSubtotal = function() {
+    var total = 0.0;
+    for(var i=0; i < this.basketItems.length; ++i)
+        total += this.getDiscountedItemCost(i);
+    return total;
+};
+
+SpreadCartBasket.prototype.getUndiscountedItemSubtotal = function() {
+    var total = 0.0;
+    for(var i=0; i < this.basketItems.length; ++i)
+        total += this.getUndiscountedItemCost(i);
+    return total;
+};
+
+SpreadCartBasket.prototype.getShippingVat = function() {
+    return this.shipping.price.vat;
+};
+
+SpreadCartBasket.prototype.getShippingCost = function() {
+    return this.shipping.price.vatIncluded;
+};
+
+SpreadCartBasket.prototype.getDiscountedTotal = function() {
+    return this.getDiscountedItemSubtotal() + this.getShippingCost();
+};
+
+SpreadCartBasket.prototype.getUndiscountedTotal = function() {
+    return this.getUndiscountedItemSubtotal() + this.getShippingCost();
+};
+
+//// ELEMENT READERS ////
+
+SpreadCartBasket.prototype.getChildren = function(parent, elemName) {
+
+    var elem = parent.children(elemName);
+    if (elem.length === 0)
+        throw new ElementNotFoundException(elemName);
+    return elem;
+};
+
+SpreadCartBasket.prototype.floatElem = function(parent, elemName) {
+    return this.toFloat(elemName, this.getChildren(parent, elemName).text());
+};
+
+SpreadCartBasket.prototype.intElem = function(parent, elemName) {
+    return this.toInt(elemName, this.getChildren(parent, elemName).text());
+};
+
+SpreadCartBasket.prototype.stringElem = function(parent, elemName) {
+    return this.getChildren(parent, elemName).text();
+};
+
+SpreadCartBasket.prototype.stringAttr = function(elem, elemName, attrName) {
+
+    var value = elem.attr(attrName);
+    if (value === null)
+        throw new ElementNotFoundException(elemName +":"+ attrName);
+    return value;
+};
+
+SpreadCartBasket.prototype.getPriceInfo = function(parent, elemName) {
+
+    var $priceInfo = this.getChildren(parent, elemName);
+    var priceInfo = {};
+    priceInfo.vatExcluded = this.floatElem($priceInfo, 'vatExcluded');
+    priceInfo.vatIncluded = this.floatElem($priceInfo, 'vatIncluded');
+    priceInfo.display = this.floatElem($priceInfo, 'display');
+    
+    var $vat = $priceInfo.children('vat');
+    if ($vat.length !== 0)
+        priceInfo.vat = this.toFloat('vat', $vat.text());
+    return priceInfo;
+}
+
+//// LEXICAL PARSERS ////
+
+SpreadCartBasket.prototype.toFloat = function(name, stringValue) {
+
+    if (!jQuery.isNumeric(stringValue))
+        throw new UnexpectedValueException(name, stringValue);
+    return parseFloat(stringValue);
+};
+
+SpreadCartBasket.prototype.toInt = function(name, stringValue) {
+
+    if (!jQuery.isNumeric(stringValue))
+        throw new UnexpectedValueException(name, stringValue);
+    return parseInt(stringValue);
+};
+
+//// Parsing Exceptions ////
+
+function ElementNotFoundException(elemName) {
+    this.message = "XML element <"+ elemName +"> not found";
+}
+
+function UnexpectedValueException(elemName, stringValue) {
+    this.message = "Unexpected value in element <"+ elemName +">: "+
+            stringValue;
+}

--- a/spreadCart_config.js
+++ b/spreadCart_config.js
@@ -22,7 +22,7 @@ var spreadCart_config = {
     //base URL the images will be pulled from. Needed to display product images in the basket. Change to .com (vs .net) for non-EU shops.
     mediaURL: "//image.spreadshirtmedia.net/image-server/v1/products/",
 
-    // location from where the customer enters checkout
+    // location where the customer goes after checkout
     returnURL: encodeURIComponent(window.location.href),
     
     // relative URL to shopping cart proxy. must be on your store's web site,
@@ -30,6 +30,33 @@ var spreadCart_config = {
     // the last component of the path is "proxy.php" when using the provided
     // PHP script or "/cart" when using the provided node.js server.
     proxyPath: "proxy.php",
+    
+    // whether or not to maximally decouple the shopping cart from the details
+    // of the SpreadShop implementation. A value of false is more responsive to
+    // the user and less taxing on the proxy server. A value of true allows
+    // the shopping cart to keep working despite some possible unexpected
+    // changes in the SpreadShop implementation. A value of true also allows
+    // this plugin to mirror changes made via the SpreadShop shopping cart.
+    decouple: false,
+    
+    // number of milliseconds to wait between attempts to use the Spreadshirt
+    // API to update the shopping cart's total quantity indicator. This is also
+    // the minimum amount of time required to update the indicator after a user
+    // adds to the shopping cart. The lower this number, the more responsive
+    // the web page is to the user, but the more traffic that is directed to
+    // the proxy server. Only used when clickTargetID is "spreadCartIcon".
+    updateMillis: 750,
+    
+    // maximum number of attempts to make trying to use the Spreadshirt API to
+    // update the shopping cart's total quantity indicator. One attempt is made
+    // every updateMillis milliseconds until either a number of attempts equal
+    // to updateTries has been made or the shopping cart is found to have
+    // changed. Lower numbers are less taxing on the proxy server but less
+    // resilient to network and server latency issues. In any case, the user
+    // need only open the shopping cart to force an update.  Only used when 
+    // clickTargetID is "spreadCartIcon". Caution: If this number is too high,
+    // Spreadshirt might think your server is misbehaving.
+    updateTries: 6,
     
     // optional function that will be called when the first item is put in the
     // cart and the last item is removed from the cart. The called method takes


### PR DESCRIPTION
Largely revised to decouple from SpreadShop JS and use Spreadshirt APIs:

(1) Now reads the basket from the Spreadshirt API, no longer from local storage, except for the apiBasketId. The basket is read into a new class SpreadCartBasket, whose data structure mirrors much of the API XML. The node.js proxy now supports a 'read' action to read the cart from the SpreadShop API. The PHP proxy will need to add this action.

(2) Upon receiving a failure to read the basket from the API, assumes that the basket is now invalid and empty. In particular, this happens upon returning to the web site after checkout.

(3) Changed proxy 'operation' parameter to 'action' parameter to match your good choice of terms in the PHP proxy. Done in both spreadCart.js and nodejs/cart.js. You'll need to update your PHP proxy.

(4) Upon adding an item to the basket, timeouts run in series reading the basket from the API until either a maximum number of tries or we get a basket with a different quantity of items. updateMillis and updateTries configure this.

(5) If the new 'decouple' configuration variable is true, the timeout series will run on every click made to a page that contains the spreadshop config variable spread_shop_config. There is no dependency on SpreadShop CSS IDs. This mode also allows spreadCart to synchronize with the SpreadShop basket.

(6) No longer dependent on the event onSpreadShopLoaded. Instead runs a timeout series at page load waiting for the necessary components to appear.

(7) The basket structure is built in its entirety at page load and its contents assigned when visible, instead of building as basket data becomes ready.

(8) When an item is deleted, the item display is immediately removed and the basket is reread from the API to update totals. This is particularly important for updating shipping cost.

(9) If the user ever deletes anything from the shopping cart while on a page that has SpreadShop, the page reloads when the user closes the cart, in order to force SpreadShop to use the modified shopping cart. We'll need to do the same when changing item quantities.

(10) Changed font of #totalQuantity to sans-serif, which is more readable when small.

(11) Replaced hardcoded "font-size:60%" in shopping cart footer notes with class="miniBasketNote", added class to CSS.

(12) Spaced the cart total row a bit from the shipping row.

(13) Changed #checkoutLink to #miniBasketCheckoutLink to reduce chances of conflict with SpreadShop or hosting site.

(14) url-encoded the 'emptyBasketUrl' checkout parameter

(15) Made basketItemName, basketItemPrice, and miniBasketLabel (totals lines) all the same font size (110%). Made miniBasketNote font size 75%.

(16) Added UTC timestamp and node.js server error log.

(17) Added "-offline" option to node.js server to have all requests return public/offline.html.
