### PR TITLE
bug fixes for product images and apiBasketId

### DIFF
--- a/nodejs/server.js
+++ b/nodejs/server.js
@@ -36,9 +36,9 @@ app.use(function(req, res, next) {
 });
 
 app.use(function(err, req, res, next) {
-    var utc = new Date().toISOString().replace('T', ' ').substr(0, 19);
+
     console.error('%sutc error: %s [%s] %j',
-            utc, req.originalUrl, err.message, err);
+            getUTCTimeString(), req.originalUrl, err.message, err);
     res.status(err.status || 500);
     
     if (req.xhr)
@@ -48,6 +48,12 @@ app.use(function(err, req, res, next) {
         res.send("<h1><center>"+ message +"</center></h1");
     }
 });
+
+//// UTILITY METHODS ////
+
+function getUTCTimeString() {
+    return new Date().toISOString().replace('T', ' ').substr(0, 19);
+}
 
 //// LAUNCH SERVER ////
 
@@ -65,5 +71,6 @@ if (process.argv.length >= 4) {
 }
     
 var server = app.listen(port, function() {
-    console.log('Listening on port ' + server.address().port);
+    console.log(getUTCTimeString() +'utc - Listening on port '+
+            server.address().port);
 });

--- a/spreadCart.js
+++ b/spreadCart.js
@@ -164,7 +164,7 @@ SpreadCartPlugin.prototype.buildCartItems = function() {
         var itemDivID = 'basketItem-'+ basketItem.id;
         jQuery('#miniBasketContent').append('<div class="basketItem" id="'+ itemDivID +'"></div>');
         var itemDiv = jQuery('#'+ itemDivID);
-        itemDiv.append('<img style="width:30%" src="'+ plugin.config.mediaURL + basketItem.element.id +'?appearanceId='+  basketItem.element.properties['appearance'] +'"/>');
+        itemDiv.append('<img style="width:30%" src="'+ plugin.config.mediaURL + basketItem.element.properties['product'] +'?appearanceId='+  basketItem.element.properties['appearance'] +'"/>');
         
         var infoDivID = 'basketItemInformation-'+ basketItem.id;
         itemDiv.append('<div class="basketItemInformation" id="'+ infoDivID +'"></div>');
@@ -289,7 +289,9 @@ SpreadCartPlugin.prototype.loadBasket = function(nextFunc) {
     if(shopBasketJSON !== null && shopBasketJSON !== "") {
         var shopBasket = JSON.parse(shopBasketJSON);
         
-        if(shopBasket !== null) {
+        if(shopBasket !== null && typeof shopBasket.apiBasketId !== "undefined"
+                && shopBasket.apiBasketId !== null)
+        {
             this.basketID = shopBasket.apiBasketId;
             this.requestReadBasket(nextFunc);
         }
@@ -298,7 +300,7 @@ SpreadCartPlugin.prototype.loadBasket = function(nextFunc) {
     // empty the basket if we ever lose the SpreadShop basket ID
     if(this.basketID === null) {
         this.basket = null;
-        nextFunc();
+        nextFunc(false);
     }
 };
 
@@ -324,6 +326,7 @@ SpreadCartPlugin.prototype.requestReadBasket = function(nextFunc) {
         function(data, status, xhr) {
 
             var basketDoc = jQuery.parseXML(xhr.responseJSON.xml);
+            // alert(xhr.responseJSON.xml);
 
             // update for successfully read (non-empty) basket
             if(jQuery(basketDoc).find('basketItem').length) {


### PR DESCRIPTION
Spreadshirt changed the ID required for product images from element@id to element/properties/product, so reflected this in code; there are circumstances where the SpreadShop cart's apiBasketId is undefined, so now treat the basket as empty without asking spreadshirt for the basket in this case (which would otherwise error); added timestamp to node.js server luanch output
